### PR TITLE
Type-Safe Identifier with various Types

### DIFF
--- a/Snabble/Core/Cart/CartEvent.swift
+++ b/Snabble/Core/Cart/CartEvent.swift
@@ -9,7 +9,7 @@ import Foundation
 // MARK: send events
 enum CartEvent {
     static func sessionStart(_ cart: ShoppingCart) {
-        guard !cart.shopId.isEmpty else {
+        guard !cart.shopId.rawValue.isEmpty else {
             return
         }
 
@@ -22,7 +22,7 @@ enum CartEvent {
     }
 
     static func sessionEnd(_ cart: ShoppingCart) {
-        guard !cart.shopId.isEmpty else {
+        guard !cart.shopId.rawValue.isEmpty else {
             return
         }
 
@@ -35,7 +35,7 @@ enum CartEvent {
     }
 
     static func cart(_ cart: ShoppingCart) {
-        if cart.shopId.isEmpty || (cart.items.isEmpty && cart.session.isEmpty) {
+        if cart.shopId.rawValue.isEmpty || (cart.items.isEmpty && cart.session.isEmpty) {
             return
         }
 

--- a/Snabble/Core/Cart/ShoppingCart.swift
+++ b/Snabble/Core/Cart/ShoppingCart.swift
@@ -80,7 +80,7 @@ public final class ShoppingCart: Codable {
 
     public init(_ config: CartConfig) {
         assert(!config.project.id.rawValue.isEmpty && config.project.id != Project.none.id, "empty projects cannot have a shopping cart")
-        assert(!config.shopId.isEmpty, "shopId is required")
+        assert(!config.shopId.rawValue.isEmpty, "shopId is required")
         self.projectId = config.project.id
         self.shopId = config.shopId
         self.maxAge = config.maxAge

--- a/Snabble/Core/Identifier.swift
+++ b/Snabble/Core/Identifier.swift
@@ -37,14 +37,14 @@ extension Identifier: Codable {
 // MARK: - ExpressibleByStringLiteral
 
 extension Identifier: ExpressibleByUnicodeScalarLiteral where Value.RawIdentifier == String {
-    public init(unicodeScalarLiteral value: Value.RawIdentifier) {
-        rawValue = value
+    public init(unicodeScalarLiteral value: UnicodeScalar) {
+        rawValue = String(describing: Character(value))
     }
 }
 
 extension Identifier: ExpressibleByExtendedGraphemeClusterLiteral where Value.RawIdentifier == String {
-    public init(extendedGraphemeClusterLiteral value: Value.RawIdentifier) {
-        rawValue = value
+    public init(extendedGraphemeClusterLiteral value: Character) {
+        rawValue = String(describing: value)
     }
 }
 

--- a/Snabble/Core/Identifier.swift
+++ b/Snabble/Core/Identifier.swift
@@ -12,7 +12,7 @@ public protocol Identifiable {
     var id: Identifier<Self> { get }
 }
 
-public struct Identifier<Value: Snabble.Identifiable>: RawRepresentable {
+public struct Identifier<Value: Identifiable>: RawRepresentable {
     public let rawValue: Value.RawIdentifier
 
     public init(rawValue: Value.RawIdentifier) {
@@ -74,10 +74,6 @@ extension Identifier: Hashable {
 
 extension Identifier: CustomStringConvertible {
     public var description: String {
-        if let stringValue = rawValue as? String {
-            return stringValue
-        } else {
-            return "\(rawValue)"
-        }
+        String(describing: rawValue)
     }
 }

--- a/Snabble/Core/Identifier.swift
+++ b/Snabble/Core/Identifier.swift
@@ -8,20 +8,15 @@
 import Foundation
 
 public protocol Identifiable {
+    associatedtype RawIdentifier: Codable & Hashable = String
     var id: Identifier<Self> { get }
 }
 
 public struct Identifier<Value: Snabble.Identifiable>: RawRepresentable {
-    public typealias RawIdentifier = String
+    public let rawValue: Value.RawIdentifier
 
-    public let rawValue: RawIdentifier
-
-    public init(rawValue: RawIdentifier) {
+    public init(rawValue: Value.RawIdentifier) {
         self.rawValue = rawValue
-    }
-
-    public var isEmpty: Bool {
-        rawValue.isEmpty
     }
 }
 
@@ -30,7 +25,7 @@ public struct Identifier<Value: Snabble.Identifiable>: RawRepresentable {
 extension Identifier: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        let rawValue = try container.decode(RawIdentifier.self)
+        let rawValue = try container.decode(Value.RawIdentifier.self)
         self.init(rawValue: rawValue)
     }
     public func encode(to encoder: Encoder) throws {
@@ -41,9 +36,29 @@ extension Identifier: Codable {
 
 // MARK: - ExpressibleByStringLiteral
 
-extension Identifier: ExpressibleByStringLiteral {
-    public init(stringLiteral value: String) {
-        self.init(rawValue: value)
+extension Identifier: ExpressibleByUnicodeScalarLiteral where Value.RawIdentifier == String {
+    public init(unicodeScalarLiteral value: Value.RawIdentifier) {
+        rawValue = value
+    }
+}
+
+extension Identifier: ExpressibleByExtendedGraphemeClusterLiteral where Value.RawIdentifier == String {
+    public init(extendedGraphemeClusterLiteral value: Value.RawIdentifier) {
+        rawValue = value
+    }
+}
+
+extension Identifier: ExpressibleByStringLiteral where Value.RawIdentifier == String {
+    public init(stringLiteral value: Value.RawIdentifier) {
+        rawValue = value
+    }
+}
+
+// MARK: - ExpressibleByIntegerLiteral
+
+extension Identifier: ExpressibleByIntegerLiteral where Value.RawIdentifier == Int {
+    public init(integerLiteral value: Value.RawIdentifier) {
+        rawValue = value
     }
 }
 
@@ -59,6 +74,10 @@ extension Identifier: Hashable {
 
 extension Identifier: CustomStringConvertible {
     public var description: String {
-        rawValue
+        if let stringValue = rawValue as? String {
+            return stringValue
+        } else {
+            return "\(rawValue)"
+        }
     }
 }


### PR DESCRIPTION
* Identifier can be used with various types 
* `String` is the default type
* add `ExpressibleByIntegerLiteral` conformance

### Examples
```swift
struct IntegerIdentifier: Identifiable {
    typealias RawIdentifier = Int
    var id: Identifier<IntegerIdentifier>
}

let identifier: Identifier<IntegerIdentifier> = 1

struct StringIdentifier: Identifiable {
    var id: Identifier<StringIdentifier>
}

let identifier: Identifier<StringIdentifier> = "dx9d-sade-231s"
```