### PR TITLE
add ExitTokenPoller

### DIFF
--- a/Snabble/Core/Cart/CheckoutData.swift
+++ b/Snabble/Core/Cart/CheckoutData.swift
@@ -386,8 +386,8 @@ public enum FailureCause: String {
 }
 
 public struct ExitToken: Codable {
-    public let format: ScanFormat
-    public let value: String
+    public let format: ScanFormat?
+    public let value: String?
 }
 
 // MARK: - Checkout Process

--- a/Snabble/UI/Payment/ExitTokenPoller.swift
+++ b/Snabble/UI/Payment/ExitTokenPoller.swift
@@ -1,0 +1,81 @@
+//
+//  ExitTokenPoller.swift
+//
+//  Copyright © 2021 snabble. All rights reserved.
+//
+
+final class ExitTokenPoller {
+    static let shared = ExitTokenPoller()
+
+    private var processTimer: Timer?
+    private var sessionTask: URLSessionTask?
+    private var project: Project?
+    private var process: CheckoutProcess?
+
+    private var completion: ((CheckoutProcess, [String: Any]?) -> Void)?
+
+    private init() {}
+
+    func startPolling(_ project: Project, _ process: CheckoutProcess, completion: @escaping (CheckoutProcess, [String: Any]?) -> Void) {
+        let allowStart = self.process == nil && self.project == nil
+        assert(allowStart, "ExitPoller already running")
+        guard allowStart else {
+            return
+        }
+
+        self.project = project
+        self.process = process
+        self.completion = completion
+
+        self.startTimer()
+    }
+
+    // MARK: - polling timer
+    private func startTimer() {
+        guard
+            let process = self.process,
+            let project = self.project
+        else {
+            return
+        }
+
+        self.processTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+            process.update(project,
+                           taskCreated: { self.sessionTask = $0 },
+                           completion: { self.update($0) })
+        }
+    }
+
+    private func stopPolling() {
+        self.processTimer?.invalidate()
+        self.processTimer = nil
+
+        self.sessionTask?.cancel()
+        self.sessionTask = nil
+
+        self.project = nil
+        self.process = nil
+        self.completion = nil
+    }
+
+    // MARK: - process updates
+    private func update(_ result: RawResult<CheckoutProcess, SnabbleError>) {
+        var continuePolling = true
+        switch result.result {
+        case .success(let process):
+            continuePolling = process.exitToken?.value == nil
+            if !continuePolling {
+                self.completion?(process, result.rawJson)
+                self.completion = nil
+            }
+        case .failure(let error):
+            Log.error(String(describing: error))
+        }
+
+        if continuePolling {
+            self.startTimer()
+        } else {
+            self.stopPolling()
+        }
+    }
+}

--- a/Snabble/UI/Payment/FulfillmentPoller.swift
+++ b/Snabble/UI/Payment/FulfillmentPoller.swift
@@ -20,12 +20,16 @@ final class FulfillmentPoller {
     private init() {}
 
     func startPolling(_ project: Project, _ process: CheckoutProcess) {
-        if self.process == nil && self.process == nil {
-            self.project = project
-            self.process = process
-
-            self.startTimer()
+        let allowStart = self.process == nil && self.project == nil
+        assert(allowStart, "FulfillmentPoller already running")
+        guard allowStart else {
+            return
         }
+
+        self.project = project
+        self.process = process
+
+        self.startTimer()
     }
 
     // MARK: - polling timer

--- a/Snabble/UI/Payment/OriginPoller.swift
+++ b/Snabble/UI/Payment/OriginPoller.swift
@@ -18,11 +18,14 @@ final class OriginPoller {
     private init() {}
 
     func startPolling(_ project: Project, _ url: String) {
-        if self.project == nil && !self.candidates.contains(url) {
-            self.project = project
-
-            self.checkCandidate(url)
+        let allowStart = self.project == nil && !self.candidates.contains(url)
+        assert(allowStart, "OriginPoller for \(url) already running")
+        guard allowStart else {
+            return
         }
+
+        self.project = project
+        self.checkCandidate(url)
     }
 
     private func stopPolling() {


### PR DESCRIPTION
Hintergrund: das Generieren des Exitcodes kann länger dauern als die Verarbeitung des Payments, daher muss in den Projekten wo das benutzt wird die App darauf warten, dass der Code da ist.