### PR TITLE
Refactor CustomAppearance

### DIFF
--- a/Snabble/UI/EmptyState/EmptyStateView.swift
+++ b/Snabble/UI/EmptyState/EmptyStateView.swift
@@ -54,10 +54,10 @@ final class ShoppingCartEmptyStateView: EmptyStateView {
 
         self.textLabel.text = "Snabble.Shoppingcart.emptyState.description".localized()
         self.button1.setTitle("Snabble.Shoppingcart.emptyState.buttonTitle".localized(), for: .normal)
-        self.button1.setTitleColor(SnabbleUI.appearance.primaryColor, for: .normal)
+        self.button1.setTitleColor(.label, for: .normal)
 
         self.button2.setTitle("Snabble.Shoppingcart.emptyState.restoreButtonTitle".localized(), for: .normal)
-        self.button2.setTitleColor(SnabbleUI.appearance.primaryColor, for: .normal)
+        self.button2.setTitleColor(.label, for: .normal)
         self.button2.isHidden = true
     }
 
@@ -73,7 +73,7 @@ final class BarcodeEntryEmptyStateView: EmptyStateView {
         self.textLabel.text = "Snabble.Scanner.enterBarcode".localized()
 
         self.button1.setTitle("", for: .normal)
-        self.button1.setTitleColor(SnabbleUI.appearance.primaryColor, for: .normal)
+        self.button1.setTitleColor(.label, for: .normal)
 
         self.button2.isHidden = true
     }

--- a/Snabble/UI/EmptyState/EmptyStateView.swift
+++ b/Snabble/UI/EmptyState/EmptyStateView.swift
@@ -20,7 +20,7 @@ internal class EmptyStateView: NibView {
         self.tapHandler = tapHandler
         super.init(frame: CGRect.zero)
 
-        self.backgroundColor = SnabbleUI.appearance.backgroundColor
+        self.backgroundColor = .systemBackground
 
         self.button1.tag = 0
         self.button2.tag = 1

--- a/Snabble/UI/Payment/EmbeddedCodesCheckoutViewController.swift
+++ b/Snabble/UI/Payment/EmbeddedCodesCheckoutViewController.swift
@@ -84,7 +84,7 @@ public final class EmbeddedCodesCheckoutViewController: UIViewController {
 
         self.pageControl.numberOfPages = self.codes.count
         self.pageControl.pageIndicatorTintColor = .lightGray
-        self.pageControl.currentPageIndicatorTintColor = SnabbleUI.appearance.primaryColor
+        self.pageControl.currentPageIndicatorTintColor = .label
         self.pageControlWrapper.isHidden = self.codes.count == 1
 
         self.collectionView.dataSource = self

--- a/Snabble/UI/Payment/Online/BaseCheckoutViewController.swift
+++ b/Snabble/UI/Payment/Online/BaseCheckoutViewController.swift
@@ -77,7 +77,7 @@ public class BaseCheckoutViewController: UIViewController {
         self.codeWidth.constant = self.codeImage.image?.size.width ?? 0
 
         self.cancelButton.setTitle("Snabble.Cancel".localized(), for: .normal)
-        self.cancelButton.setTitleColor(SnabbleUI.appearance.primaryColor, for: .normal)
+        self.cancelButton.setTitleColor(.label, for: .normal)
 
         self.navigationItem.hidesBackButton = true
 

--- a/Snabble/UI/Scanner/BarcodeEntryViewController.swift
+++ b/Snabble/UI/Scanner/BarcodeEntryViewController.swift
@@ -53,7 +53,7 @@ public final class BarcodeEntryViewController: UIViewController {
 
         self.keyboardObserver = KeyboardObserver(handler: self)
 
-        self.view.backgroundColor = SnabbleUI.appearance.backgroundColor
+        self.view.backgroundColor = .systemBackground
         self.tableView.backgroundColor = .clear
     }
 

--- a/Snabble/UI/Scanner/ScanConfirmationView.swift
+++ b/Snabble/UI/Scanner/ScanConfirmationView.swift
@@ -51,7 +51,7 @@ final class ScanConfirmationView: DesignableView {
         self.plusButton.makeBorderedButton()
 
         self.quantityField.font = UIFont.monospacedDigitSystemFont(ofSize: 21, weight: .regular)
-        self.quantityField.tintColor = SnabbleUI.appearance.primaryColor
+        self.quantityField.tintColor = .label
         self.quantityField.delegate = self
         self.quantityField.addDoneButton()
 

--- a/Snabble/UI/Scanner/ScannerViewController.swift
+++ b/Snabble/UI/Scanner/ScannerViewController.swift
@@ -191,7 +191,7 @@ public final class ScannerViewController: UIViewController {
         appearance.torchButtonImage = UIImage.fromBundle("SnabbleSDK/icon-light-inactive")?.recolored(with: .white)
         appearance.torchButtonActiveImage = UIImage.fromBundle("SnabbleSDK/icon-light-active")
         appearance.enterButtonImage = UIImage.fromBundle("SnabbleSDK/icon-entercode")?.recolored(with: .white)
-        appearance.backgroundColor = SnabbleUI.appearance.buttonBackgroundColor
+        appearance.backgroundColor = SnabbleUI.appearance.accentColor
         appearance.textColor = SnabbleUI.appearance.buttonTextColor
         appearance.reticleCornerRadius = 3
 

--- a/Snabble/UI/Scanner/ScannerViewController.swift
+++ b/Snabble/UI/Scanner/ScannerViewController.swift
@@ -192,7 +192,7 @@ public final class ScannerViewController: UIViewController {
         appearance.torchButtonActiveImage = UIImage.fromBundle("SnabbleSDK/icon-light-active")
         appearance.enterButtonImage = UIImage.fromBundle("SnabbleSDK/icon-entercode")?.recolored(with: .white)
         appearance.backgroundColor = SnabbleUI.appearance.accentColor
-        appearance.textColor = SnabbleUI.appearance.buttonTextColor
+        appearance.textColor = SnabbleUI.appearance.accentContrastColor
         appearance.reticleCornerRadius = 3
 
         return appearance

--- a/Snabble/UI/ShoppingCart/ShoppingCartTableCell.swift
+++ b/Snabble/UI/ShoppingCart/ShoppingCartTableCell.swift
@@ -301,7 +301,7 @@ extension ShoppingCartTableCell: UITextFieldDelegate {
 extension ShoppingCartTableCell: CustomizableAppearance {
     func setCustomAppearance(_ appearance: CustomAppearance) {
         self.quantityWrapper.backgroundColor = appearance.accentColor
-        self.quantityLabel.textColor = appearance.buttonTextColor
+        self.quantityLabel.textColor = appearance.accentContrastColor
     }
 }
 

--- a/Snabble/UI/ShoppingCart/ShoppingCartTableCell.swift
+++ b/Snabble/UI/ShoppingCart/ShoppingCartTableCell.swift
@@ -55,7 +55,7 @@ final class ShoppingCartTableCell: UITableViewCell {
         self.quantityWrapper.layer.cornerRadius = 2
         self.quantityWrapper.layer.masksToBounds = true
 
-        self.quantityInput.tintColor = SnabbleUI.appearance.primaryColor
+        self.quantityInput.tintColor = .label
         let toolbar = self.quantityInput.addDoneButton()
         self.doneButton = toolbar.items?.last
         self.quantityInput.delegate = self

--- a/Snabble/UI/ShoppingCart/ShoppingCartTableCell.swift
+++ b/Snabble/UI/ShoppingCart/ShoppingCartTableCell.swift
@@ -51,7 +51,7 @@ final class ShoppingCartTableCell: UITableViewCell {
         self.quantityLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 13, weight: .bold)
         self.quantityLabel.backgroundColor = .clear
 
-        self.quantityWrapper.backgroundColor = SnabbleUI.appearance.buttonBackgroundColor
+        self.quantityWrapper.backgroundColor = SnabbleUI.appearance.accentColor
         self.quantityWrapper.layer.cornerRadius = 2
         self.quantityWrapper.layer.masksToBounds = true
 
@@ -114,7 +114,7 @@ final class ShoppingCartTableCell: UITableViewCell {
         self.loadImage()
         if self.delegate.showImages {
             let icon = UIImage.fromBundle("SnabbleSDK/icon-percent")
-            self.productImage.image = icon?.recolored(with: SnabbleUI.appearance.buttonBackgroundColor)
+            self.productImage.image = icon?.recolored(with: SnabbleUI.appearance.accentColor)
             self.imageWrapper.isHidden = false
         }
     }
@@ -130,7 +130,7 @@ final class ShoppingCartTableCell: UITableViewCell {
         self.loadImage()
         if self.delegate.showImages {
             let icon = UIImage.fromBundle("SnabbleSDK/icon-giveaway")
-            self.productImage.image = icon?.recolored(with: SnabbleUI.appearance.buttonBackgroundColor)
+            self.productImage.image = icon?.recolored(with: SnabbleUI.appearance.accentColor)
             self.imageWrapper.isHidden = false
         }
     }
@@ -300,7 +300,7 @@ extension ShoppingCartTableCell: UITextFieldDelegate {
 
 extension ShoppingCartTableCell: CustomizableAppearance {
     func setCustomAppearance(_ appearance: CustomAppearance) {
-        self.quantityWrapper.backgroundColor = appearance.buttonBackgroundColor
+        self.quantityWrapper.backgroundColor = appearance.accentColor
         self.quantityLabel.textColor = appearance.buttonTextColor
     }
 }

--- a/Snabble/UI/ShoppingCart/ShoppingCartViewController.swift
+++ b/Snabble/UI/ShoppingCart/ShoppingCartViewController.swift
@@ -127,7 +127,7 @@ public final class ShoppingCartViewController: UIViewController {
         self.methodSelector = PaymentMethodSelector(self, self.methodSelectionView, self.methodIcon, self.methodSpinner, self.shoppingCart)
         self.methodSelector?.paymentMethodNavigationDelegate = self.paymentMethodNavigationDelegate
 
-        self.view.backgroundColor = SnabbleUI.appearance.backgroundColor
+        self.view.backgroundColor = .systemBackground
 
         self.emptyState = ShoppingCartEmptyStateView({ [weak self] button in self?.emptyStateButtonTapped(button) })
         self.emptyState.addTo(self.view)

--- a/Snabble/UI/Utilities/CustomAppearance.swift
+++ b/Snabble/UI/Utilities/CustomAppearance.swift
@@ -6,17 +6,24 @@
 //  "Chameleon mode" support
 
 public protocol CustomAppearance {
-    var primaryColor: UIColor { get }
     var backgroundColor: UIColor { get }
 
     var buttonBorderColor: UIColor { get }
     var buttonShadowColor: UIColor { get }
+
     var buttonBackgroundColor: UIColor { get }
     var buttonTextColor: UIColor { get }
 
-    var stepperButtonBackgroundColor: UIColor { get }
-
     var titleIcon: UIImage? { get }
+}
+
+public extension CustomAppearance {
+    var backgroundColor: UIColor { .systemBackground }
+    var buttonBackgroundColor: UIColor { UIColor(rgbValue: 0x0077bb) }
+    var buttonTextColor: UIColor { .white }
+    var buttonShadowColor: UIColor { UIColor(rgbaValue: 0x2222223f) }
+    var buttonBorderColor: UIColor { UIColor(rgbaValue: 0x00000019) }
+    var titleIcon: UIImage? { nil }
 }
 
 public protocol CustomizableAppearance: AnyObject {

--- a/Snabble/UI/Utilities/CustomAppearance.swift
+++ b/Snabble/UI/Utilities/CustomAppearance.swift
@@ -6,7 +6,7 @@
 //  "Chameleon mode" support
 
 public protocol CustomAppearance {
-    var buttonBackgroundColor: UIColor { get }
+    var accentColor: UIColor { get }
     var buttonTextColor: UIColor { get }
 
     var buttonBorderColor: UIColor { get }
@@ -16,7 +16,7 @@ public protocol CustomAppearance {
 }
 
 public extension CustomAppearance {
-    var buttonBackgroundColor: UIColor { UIColor(rgbValue: 0x0077bb) }
+    var accentColor: UIColor { UIColor(rgbValue: 0x0077bb) }
     var buttonTextColor: UIColor { .white }
 
     var buttonShadowColor: UIColor { UIColor(rgbaValue: 0x2222223f) }
@@ -30,7 +30,7 @@ public protocol CustomizableAppearance: AnyObject {
 
 extension UIButton: CustomizableAppearance {
     public func setCustomAppearance(_ appearance: CustomAppearance) {
-        self.backgroundColor = appearance.buttonBackgroundColor
+        self.backgroundColor = appearance.accentColor
         self.tintColor = appearance.buttonTextColor
     }
 }

--- a/Snabble/UI/Utilities/CustomAppearance.swift
+++ b/Snabble/UI/Utilities/CustomAppearance.swift
@@ -6,11 +6,11 @@
 //  "Chameleon mode" support
 
 public protocol CustomAppearance {
-    var buttonBorderColor: UIColor { get }
-    var buttonShadowColor: UIColor { get }
-
     var buttonBackgroundColor: UIColor { get }
     var buttonTextColor: UIColor { get }
+
+    var buttonBorderColor: UIColor { get }
+    var buttonShadowColor: UIColor { get }
 
     var titleIcon: UIImage? { get }
 }
@@ -18,6 +18,7 @@ public protocol CustomAppearance {
 public extension CustomAppearance {
     var buttonBackgroundColor: UIColor { UIColor(rgbValue: 0x0077bb) }
     var buttonTextColor: UIColor { .white }
+
     var buttonShadowColor: UIColor { UIColor(rgbaValue: 0x2222223f) }
     var buttonBorderColor: UIColor { UIColor(rgbaValue: 0x00000019) }
     var titleIcon: UIImage? { nil }

--- a/Snabble/UI/Utilities/CustomAppearance.swift
+++ b/Snabble/UI/Utilities/CustomAppearance.swift
@@ -6,8 +6,6 @@
 //  "Chameleon mode" support
 
 public protocol CustomAppearance {
-    var backgroundColor: UIColor { get }
-
     var buttonBorderColor: UIColor { get }
     var buttonShadowColor: UIColor { get }
 
@@ -18,7 +16,6 @@ public protocol CustomAppearance {
 }
 
 public extension CustomAppearance {
-    var backgroundColor: UIColor { .systemBackground }
     var buttonBackgroundColor: UIColor { UIColor(rgbValue: 0x0077bb) }
     var buttonTextColor: UIColor { .white }
     var buttonShadowColor: UIColor { UIColor(rgbaValue: 0x2222223f) }

--- a/Snabble/UI/Utilities/CustomAppearance.swift
+++ b/Snabble/UI/Utilities/CustomAppearance.swift
@@ -7,20 +7,15 @@
 
 public protocol CustomAppearance {
     var accentColor: UIColor { get }
-    var buttonTextColor: UIColor { get }
-
-    var buttonBorderColor: UIColor { get }
-    var buttonShadowColor: UIColor { get }
+    var accentContrastColor: UIColor { get }
 
     var titleIcon: UIImage? { get }
 }
 
 public extension CustomAppearance {
     var accentColor: UIColor { UIColor(rgbValue: 0x0077bb) }
-    var buttonTextColor: UIColor { .white }
+    var accentContrastColor: UIColor { .white }
 
-    var buttonShadowColor: UIColor { UIColor(rgbaValue: 0x2222223f) }
-    var buttonBorderColor: UIColor { UIColor(rgbaValue: 0x00000019) }
     var titleIcon: UIImage? { nil }
 }
 
@@ -31,6 +26,6 @@ public protocol CustomizableAppearance: AnyObject {
 extension UIButton: CustomizableAppearance {
     public func setCustomAppearance(_ appearance: CustomAppearance) {
         self.backgroundColor = appearance.accentColor
-        self.tintColor = appearance.buttonTextColor
+        self.tintColor = appearance.accentContrastColor
     }
 }

--- a/Snabble/UI/Utilities/Misc.swift
+++ b/Snabble/UI/Utilities/Misc.swift
@@ -19,7 +19,7 @@ extension UIView {
     /// add a "bordered button" appearance to this view
     public func makeBorderedButton() {
         self.layer.cornerRadius = 6
-        self.backgroundColor = SnabbleUI.appearance.stepperButtonBackgroundColor
+        self.backgroundColor = .secondarySystemBackground
         self.layer.borderWidth = 0.5
         self.layer.borderColor = SnabbleUI.appearance.buttonBorderColor.cgColor
     }

--- a/Snabble/UI/Utilities/Misc.swift
+++ b/Snabble/UI/Utilities/Misc.swift
@@ -13,7 +13,7 @@ extension UIView {
     public func makeSnabbleButton() {
         self.layer.cornerRadius = 8
         self.backgroundColor = SnabbleUI.appearance.accentColor
-        self.tintColor = SnabbleUI.appearance.buttonTextColor
+        self.tintColor = SnabbleUI.appearance.accentContrastColor
     }
 
     /// add a "bordered button" appearance to this view
@@ -21,12 +21,12 @@ extension UIView {
         self.layer.cornerRadius = 6
         self.backgroundColor = .secondarySystemBackground
         self.layer.borderWidth = 0.5
-        self.layer.borderColor = SnabbleUI.appearance.buttonBorderColor.cgColor
+        self.layer.borderColor = UIColor.borderColor.cgColor
     }
 
     /// add a "rounded card" appearance to this view
     public func addCornersAndShadow(backgroundColor: UIColor, cornerRadius: CGFloat) {
-        self.layer.shadowColor = SnabbleUI.appearance.buttonShadowColor.cgColor
+        self.layer.shadowColor = UIColor.shadowColor.cgColor
         self.layer.shadowOffset = CGSize(width: 0, height: 1)
         self.layer.shadowOpacity = 0.5
         self.layer.shadowRadius = 2.0

--- a/Snabble/UI/Utilities/Misc.swift
+++ b/Snabble/UI/Utilities/Misc.swift
@@ -12,7 +12,7 @@ extension UIView {
     /// add a "rounded button" appearance to this view
     public func makeSnabbleButton() {
         self.layer.cornerRadius = 8
-        self.backgroundColor = SnabbleUI.appearance.buttonBackgroundColor
+        self.backgroundColor = SnabbleUI.appearance.accentColor
         self.tintColor = SnabbleUI.appearance.buttonTextColor
     }
 

--- a/Snabble/UI/Utilities/SnabbleUI.swift
+++ b/Snabble/UI/Utilities/SnabbleUI.swift
@@ -50,21 +50,8 @@ public enum SnabbleUI {
     }
 }
 
-private struct SnabbleAppearance: CustomAppearance {
-    var primaryColor: UIColor = .black
-    var backgroundColor: UIColor = .white
-
-    // colors for buttons
-    var buttonShadowColor: UIColor = .black
-    var buttonBorderColor: UIColor = .black
-    var buttonBackgroundColor: UIColor = .lightGray
-    var buttonTextColor: UIColor = .white
-
-    // bg color for the "stepper" buttons
-    var stepperButtonBackgroundColor: UIColor = .lightGray
-
-    var titleIcon: UIImage?
-}
+// Uses default implementations of the procotol
+private struct SnabbleAppearance: CustomAppearance {}
 
 // since we can't have NSHashTable<CustomizableAppearance>, roll our own primitive weak wrapper
 private class WeakCustomizableAppearance: Equatable, Hashable {

--- a/Snabble/UI/Utilities/UIColor+Compatibility.swift
+++ b/Snabble/UI/Utilities/UIColor+Compatibility.swift
@@ -10,99 +10,99 @@ import UIKit
 import ColorCompatibility
 
 extension UIColor {
-    public static var label: UIColor {
+    static var label: UIColor {
         ColorCompatibility.label
     }
 
-    public static var secondaryLabel: UIColor {
+    static var secondaryLabel: UIColor {
         ColorCompatibility.secondaryLabel
     }
 
-    public static var tertiaryLabel: UIColor {
+    static var tertiaryLabel: UIColor {
         ColorCompatibility.tertiaryLabel
     }
 
-    public static var quaternaryLabel: UIColor {
+    static var quaternaryLabel: UIColor {
         ColorCompatibility.quaternaryLabel
     }
 
-    public static var systemFill: UIColor {
+    static var systemFill: UIColor {
         ColorCompatibility.systemFill
     }
 
-    public static var secondarySystemFill: UIColor {
+    static var secondarySystemFill: UIColor {
         ColorCompatibility.secondarySystemFill
     }
 
-    public static var tertiarySystemFill: UIColor {
+    static var tertiarySystemFill: UIColor {
         ColorCompatibility.tertiarySystemFill
     }
 
-    public static var quaternarySystemFill: UIColor {
+    static var quaternarySystemFill: UIColor {
         ColorCompatibility.quaternarySystemFill
     }
 
-    public static var placeholderText: UIColor {
+    static var placeholderText: UIColor {
         ColorCompatibility.placeholderText
     }
 
-    public static var systemBackground: UIColor {
+    static var systemBackground: UIColor {
         ColorCompatibility.systemBackground
     }
 
-    public static var secondarySystemBackground: UIColor {
+    static var secondarySystemBackground: UIColor {
         ColorCompatibility.secondarySystemBackground
     }
 
-    public static var tertiarySystemBackground: UIColor {
+    static var tertiarySystemBackground: UIColor {
         ColorCompatibility.tertiarySystemBackground
     }
 
-    public static var systemGroupedBackground: UIColor {
+    static var systemGroupedBackground: UIColor {
         ColorCompatibility.systemGroupedBackground
     }
 
-    public static var secondarySystemGroupedBackground: UIColor {
+    static var secondarySystemGroupedBackground: UIColor {
         ColorCompatibility.secondarySystemGroupedBackground
     }
 
-    public static var tertiarySystemGroupedBackground: UIColor {
+    static var tertiarySystemGroupedBackground: UIColor {
         ColorCompatibility.tertiarySystemGroupedBackground
     }
 
-    public static var separator: UIColor {
+    static var separator: UIColor {
         ColorCompatibility.separator
     }
 
-    public static var opaqueSeparator: UIColor {
+    static var opaqueSeparator: UIColor {
         ColorCompatibility.opaqueSeparator
     }
 
-    public static var link: UIColor {
+    static var link: UIColor {
         ColorCompatibility.link
     }
 
-    public static var systemIndigo: UIColor {
+    static var systemIndigo: UIColor {
         ColorCompatibility.systemIndigo
     }
 
-    public static var systemGray2: UIColor {
+    static var systemGray2: UIColor {
         ColorCompatibility.systemGray2
     }
 
-    public static var systemGray3: UIColor {
+    static var systemGray3: UIColor {
         ColorCompatibility.systemGray3
     }
 
-    public static var systemGray4: UIColor {
+    static var systemGray4: UIColor {
         ColorCompatibility.systemGray4
     }
 
-    public static var systemGray5: UIColor {
+    static var systemGray5: UIColor {
         ColorCompatibility.systemGray5
     }
 
-    public static var systemGray6: UIColor {
+    static var systemGray6: UIColor {
         ColorCompatibility.systemGray6
     }
 }

--- a/Snabble/UI/Utilities/UIColor+HEX.swift
+++ b/Snabble/UI/Utilities/UIColor+HEX.swift
@@ -1,0 +1,30 @@
+//
+//  UIColor+HEX.swift
+//  Snabble
+//
+//  Created by Andreas Osberghaus on 21.01.21.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+  convenience init(rgbaValue: UInt32) {
+    let obaque = UInt32(0xff)
+    let red = CGFloat((rgbaValue >> 24) & obaque) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & obaque) / 255.0
+    let blue = CGFloat((rgbaValue >> 8) & obaque) / 255.0
+    let alpha = CGFloat((rgbaValue) & obaque) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+
+  convenience init(rgbValue: UInt32) {
+    let obaque = UInt32(0xff)
+    let red = CGFloat((rgbValue >> 16) & obaque) / 255.0
+    let green = CGFloat((rgbValue >> 8) & obaque) / 255.0
+    let blue = CGFloat((rgbValue) & obaque) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: 1.0)
+  }
+}

--- a/Snabble/UI/Utilities/UIColor+Snabble.swift
+++ b/Snabble/UI/Utilities/UIColor+Snabble.swift
@@ -1,0 +1,14 @@
+//
+//  UIColor+Snabble.swift
+//  Snabble
+//
+//  Created by Andreas Osberghaus on 21.01.21.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    static var shadowColor = UIColor(rgbaValue: 0x2222223f)
+    static var borderColor = UIColor(rgbaValue: 0x00000019)
+}


### PR DESCRIPTION
* removes not customized colors
   * replaces with a system color if suitable
   * moves the color to `UIColor+Snabble.swift`
* renames colors to declarative names
* adds a default implement of `CustomAppearance`
* changes protection level to internal for `UIColor+Compatibility.swift`
