### PR TITLE
replaces Capable/Colors with WCAG-Colors

### DIFF
--- a/Snabble.podspec
+++ b/Snabble.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
     ui.dependency 'Snabble/Core'
     ui.dependency 'SDCAlertView', '~> 12'
     ui.dependency 'ColorCompatibility'
-    ui.dependency 'Capable/Colors'
+    ui.dependency 'WCAG-Colors'
     ui.dependency 'DeviceKit', '~> 4'
     ui.dependency 'Pulley', '~> 2.9'
 

--- a/Snabble/UI/Scanner/ScanConfirmationView.swift
+++ b/Snabble/UI/Scanner/ScanConfirmationView.swift
@@ -5,7 +5,7 @@
 //
 
 import UIKit
-import Capable
+import WCAG_Colors
 
 protocol ScanConfirmationViewDelegate: AnalyticsDelegate {
     func closeConfirmation(_ item: CartItem?)

--- a/Snabble/UI/Utilities/UIColor+Contrast.swift
+++ b/Snabble/UI/Utilities/UIColor+Contrast.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 import UIKit
-import Capable
+import WCAG_Colors
 
 extension UIColor {
     static var contrasts: [UIColor]?


### PR DESCRIPTION
* removes `Capable/Colors`
* adds [`WCAG-Colors`](https://github.com/chrs1885/WCAG-Colors) as replacement

`Capable` wurde auf Version 2.0.0 hochgezogen und dabei wurde die Colors Funktionalität in `WCAG-Colors` herausgezogen. `Capable/Colors` wird somit nicht mehr gewartet.

