### PR TITLE
PayoneCreditCardEditViewController dynamic fonts added

### DIFF
--- a/Snabble/UI/PaymentMethods/PayoneCreditCardEditViewController.swift
+++ b/Snabble/UI/PaymentMethods/PayoneCreditCardEditViewController.swift
@@ -199,6 +199,10 @@ public final class PayoneCreditCardEditViewController: UIViewController {
     private func setupView() {
         view.backgroundColor = .systemBackground
 
+        if #available(iOS 15, *) {
+            view.restrictDynamicTypeSize(from: nil, to: .extraExtraExtraLarge)
+        }
+
         // container for the "display-only" mode
         displayContainer.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(displayContainer)
@@ -206,23 +210,32 @@ public final class PayoneCreditCardEditViewController: UIViewController {
 
         explanation.translatesAutoresizingMaskIntoConstraints = false
         explanation.numberOfLines = 0
-        explanation.font = .systemFont(ofSize: 13)
+        explanation.font = UIFont.preferredFont(forTextStyle: .footnote)
+        explanation.adjustsFontForContentSizeCategory = true
         displayContainer.addSubview(explanation)
 
         cardNumberLabel.translatesAutoresizingMaskIntoConstraints = false
+        cardNumberLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        cardNumberLabel.adjustsFontForContentSizeCategory = true
         displayContainer.addSubview(cardNumberLabel)
 
         cardNumber.translatesAutoresizingMaskIntoConstraints = false
         cardNumber.isEnabled = false
         cardNumber.borderStyle = .roundedRect
+        cardNumber.font = UIFont.preferredFont(forTextStyle: .body)
+        cardNumber.adjustsFontForContentSizeCategory = true
         displayContainer.addSubview(cardNumber)
 
         expDateLabel.translatesAutoresizingMaskIntoConstraints = false
+        expDateLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        expDateLabel.adjustsFontForContentSizeCategory = true
         displayContainer.addSubview(expDateLabel)
 
         expirationDate.translatesAutoresizingMaskIntoConstraints = false
         expirationDate.isEnabled = false
         expirationDate.borderStyle = .roundedRect
+        expirationDate.font = UIFont.preferredFont(forTextStyle: .body)
+        expirationDate.adjustsFontForContentSizeCategory = true
         displayContainer.addSubview(expirationDate)
 
         NSLayoutConstraint.activate([

--- a/documentation/Changelog.md
+++ b/documentation/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added dynamic fonts to several views #Apps-231
+* Added dynamic fonts to PayoneCreditCardEditViewController #Apps-231
 
 ## [0.19.2] - 2022-5-25
 


### PR DESCRIPTION
Steps to check:

1.  At `RawPaymentMethod+UI.swift`
`private func creditCardEditViewController(_ projectId: Identifier<Project>?, _ analyticsDelegate: AnalyticsDelegate?) -> UIViewController?`

should return:
`return PayoneCreditCardEditViewController(brand: CreditCardBrand.forMethod(self), projectId, analyticsDelegate)`

2. Tap to payment methods at Shopping Cart, choose Mastercard
