### PR TITLE
Scanner section dynamic content

### DIFF
--- a/Snabble/UI/Scanner/BarcodeEntryViewController.swift
+++ b/Snabble/UI/Scanner/BarcodeEntryViewController.swift
@@ -49,7 +49,7 @@ public final class BarcodeEntryViewController: UIViewController {
 
         if #available(iOS 15, *) {
             view.restrictDynamicTypeSize(from: nil, to: .extraExtraExtraLarge)
-        }4
+        }
 
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         searchBar.delegate = self

--- a/Snabble/UI/Scanner/BarcodeEntryViewController.swift
+++ b/Snabble/UI/Scanner/BarcodeEntryViewController.swift
@@ -47,6 +47,10 @@ public final class BarcodeEntryViewController: UIViewController {
     override public func viewDidLoad() {
         super.viewDidLoad()
 
+        if #available(iOS 15, *) {
+            view.restrictDynamicTypeSize(from: nil, to: .extraExtraExtraLarge)
+        }4
+
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         searchBar.delegate = self
         searchBar.keyboardType = .numberPad

--- a/Snabble/UI/Scanner/CheckoutBar.swift
+++ b/Snabble/UI/Scanner/CheckoutBar.swift
@@ -48,13 +48,15 @@ final class CheckoutBar: UIView {
 
         let itemCountLabel = UILabel()
         itemCountLabel.translatesAutoresizingMaskIntoConstraints = false
-        itemCountLabel.font = UIFont.systemFont(ofSize: 13)
+        itemCountLabel.font = .preferredFont(forTextStyle: .footnote)
+        itemCountLabel.adjustsFontForContentSizeCategory = true
         itemCountLabel.textColor = .secondaryLabel
         itemCountLabel.textAlignment = .left
 
         let totalPriceLabel = UILabel()
         totalPriceLabel.translatesAutoresizingMaskIntoConstraints = false
-        totalPriceLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 22, weight: .bold)
+        totalPriceLabel.font = .preferredFont(forTextStyle: .title2, weight: .bold)
+        totalPriceLabel.adjustsFontForContentSizeCategory = true
         totalPriceLabel.textColor = .label
         totalPriceLabel.textAlignment = .right
 
@@ -80,7 +82,8 @@ final class CheckoutBar: UIView {
 
         let noPaymentLabel = UILabel()
         noPaymentLabel.translatesAutoresizingMaskIntoConstraints = false
-        noPaymentLabel.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+        noPaymentLabel.font = .preferredFont(forTextStyle: .body, weight: .medium)
+        noPaymentLabel.adjustsFontForContentSizeCategory = true
         noPaymentLabel.textColor = .label
         noPaymentLabel.textAlignment = .center
         noPaymentLabel.text = L10n.Snabble.Shoppingcart.BuyProducts.selectPaymentMethod
@@ -100,7 +103,7 @@ final class CheckoutBar: UIView {
         checkoutButton.setTitle(L10n.Snabble.Shoppingcart.BuyProducts.now, for: .normal)
         let disabledColor = SnabbleUI.appearance.accentColor.contrast?.withAlphaComponent(0.5)
         checkoutButton.setTitleColor(disabledColor, for: .disabled)
-        checkoutButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        checkoutButton.preferredFont(forTextStyle: .headline)
         checkoutButton.makeSnabbleButton()
         checkoutButton.isEnabled = true
         checkoutButton.isUserInteractionEnabled = true
@@ -126,7 +129,6 @@ final class CheckoutBar: UIView {
         self.checkoutButton = checkoutButton
 
         NSLayoutConstraint.activate([
-
             summaryLayoutGuide.topAnchor.constraint(equalTo: topAnchor),
             summaryLayoutGuide.leadingAnchor.constraint(equalTo: leadingAnchor),
             summaryLayoutGuide.trailingAnchor.constraint(equalTo: trailingAnchor),

--- a/Snabble/UI/Scanner/ScanConfirmationView.swift
+++ b/Snabble/UI/Scanner/ScanConfirmationView.swift
@@ -80,7 +80,7 @@ final class ScanConfirmationView: UIView {
         let cartButton = UIButton(type: .system)
         cartButton.translatesAutoresizingMaskIntoConstraints = false
         cartButton.setTitle(L10n.Snabble.Scanner.addToCart, for: .normal)
-        cartButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        cartButton.preferredFont(forTextStyle: .headline)
         cartButton.makeSnabbleButton()
         cartButton.isUserInteractionEnabled = true
         cartButton.addTarget(self, action: #selector(cartButtonTapped(_:)), for: .touchUpInside)
@@ -93,22 +93,27 @@ final class ScanConfirmationView: UIView {
         productStack.spacing = 4
 
         let subtitleLabel = customLabel
-        subtitleLabel.font = UIFont.systemFont(ofSize: 13)
+        subtitleLabel.font = .preferredFont(forTextStyle: .footnote)
+        subtitleLabel.adjustsFontForContentSizeCategory = true
 
         let productNameLabel = customLabel
-        productNameLabel.font = UIFont.systemFont(ofSize: 17, weight: .bold)
+        productNameLabel.font = .preferredFont(forTextStyle: .body, weight: .bold)
+        productNameLabel.adjustsFontForContentSizeCategory = true
 
         let originalPriceLabel = customLabel
-        originalPriceLabel.font = UIFont.systemFont(ofSize: 17)
+        originalPriceLabel.font = .preferredFont(forTextStyle: .body)
+        originalPriceLabel.adjustsFontForContentSizeCategory = true
         originalPriceLabel.textColor = .secondaryLabel
 
         let priceLabel = customLabel
-        priceLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 17, weight: .regular)
+        priceLabel.font = .preferredFont(forTextStyle: .body)
+        priceLabel.adjustsFontForContentSizeCategory = true
 
         let manualDiscountButton = UIButton(type: .system)
         manualDiscountButton.translatesAutoresizingMaskIntoConstraints = false
         manualDiscountButton.setTitle(L10n.Snabble.addDiscount, for: .normal)
-        manualDiscountButton.titleLabel?.font = UIFont.systemFont(ofSize: 17)
+        manualDiscountButton.preferredFont(forTextStyle: .body)
+
         let contrastRatio = UIColor.getContrastRatio(forTextColor: SnabbleUI.appearance.accentColor,
                                                      onBackgroundColor: .systemBackground)
         let conformanceLevel = ConformanceLevel(contrastRatio: contrastRatio ?? 1, fontSize: 17, isBoldFont: false)
@@ -138,7 +143,8 @@ final class ScanConfirmationView: UIView {
 
         let quantityField = UITextField()
         quantityField.translatesAutoresizingMaskIntoConstraints = false
-        quantityField.font = UIFont.monospacedDigitSystemFont(ofSize: 21, weight: .regular)
+        quantityField.font = .preferredFont(forTextStyle: .title3)
+        quantityField.adjustsFontForContentSizeCategory = true
         quantityField.tintColor = .label
         quantityField.delegate = self
         quantityField.addDoneButton()
@@ -147,7 +153,8 @@ final class ScanConfirmationView: UIView {
         quantityField.keyboardType = .numberPad
 
         let unitLabel = customLabel
-        unitLabel.font = UIFont.systemFont(ofSize: 17)
+        unitLabel.font = .preferredFont(forTextStyle: .body)
+        unitLabel.adjustsFontForContentSizeCategory = true
         unitLabel.textAlignment = .natural
 
         addSubview(closeButton)

--- a/Snabble/UI/Scanner/ScannerDrawerViewController.swift
+++ b/Snabble/UI/Scanner/ScannerDrawerViewController.swift
@@ -173,7 +173,6 @@ final class ScannerDrawerViewController: UIViewController {
         if #available(iOS 15, *) {
             self.view.restrictDynamicTypeSize(from: nil, to: .extraExtraExtraLarge)
         }
-
     }
 
     override func viewDidLoad() {

--- a/Snabble/UI/Scanner/ScannerDrawerViewController.swift
+++ b/Snabble/UI/Scanner/ScannerDrawerViewController.swift
@@ -169,6 +169,11 @@ final class ScannerDrawerViewController: UIViewController {
         self.segmentedControl = segmentedControl
         self.innerSpacer = innerSpacer
         self.bottomView = bottomView
+
+        if #available(iOS 15, *) {
+            self.view.restrictDynamicTypeSize(from: nil, to: .extraExtraExtraLarge)
+        }
+
     }
 
     override func viewDidLoad() {

--- a/Snabble/UI/Scanner/ScannerShoppingListViewController.swift
+++ b/Snabble/UI/Scanner/ScannerShoppingListViewController.swift
@@ -28,6 +28,10 @@ final class ScannerShoppingListViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if #available(iOS 15, *) {
+            self.view.restrictDynamicTypeSize(from: nil, to: .extraExtraExtraLarge)
+        }
+
         tableView.delegate = self
         tableView.dataSource = self
         tableView.tableFooterView = UIView(frame: .zero)
@@ -81,10 +85,6 @@ final class ScannerShoppingListViewController: UITableViewController {
 
 // MARK: - TableView
 extension ScannerShoppingListViewController {
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 50
-    }
-
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return shoppingList?.count ?? 0
     }

--- a/Snabble/UI/Scanner/ScanningMessageView.swift
+++ b/Snabble/UI/Scanner/ScanningMessageView.swift
@@ -44,7 +44,8 @@ final class ScanningMessageView: UIView {
 
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: 17)
+        label.font = .preferredFont(forTextStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .label
         label.textAlignment = .natural
         label.numberOfLines = 0

--- a/Snabble/UI/Scanner/ScanningViewController.swift
+++ b/Snabble/UI/Scanner/ScanningViewController.swift
@@ -91,6 +91,9 @@ final class ScanningViewController: UIViewController {
     override public func loadView() {
         super.loadView()
 
+        if #available(iOS 15, *) {
+            self.view.restrictDynamicTypeSize(from: nil, to: .extraExtraExtraLarge)
+        }
         let spinner = UIActivityIndicatorView()
         spinner.translatesAutoresizingMaskIntoConstraints = false
         spinner.color = UIColor.systemGray

--- a/Snabble/UI/Scanner/ShoppingListCellView.swift
+++ b/Snabble/UI/Scanner/ShoppingListCellView.swift
@@ -45,10 +45,11 @@ final class ShoppingListCellView: UIView {
 
         let nameLabel = UILabel()
         nameLabel.translatesAutoresizingMaskIntoConstraints = false
-        nameLabel.font = UIFont.systemFont(ofSize: 15)
+        nameLabel.font = .preferredFont(forTextStyle: .subheadline)
+        nameLabel.adjustsFontForContentSizeCategory = true
         nameLabel.textColor = .label
         nameLabel.textAlignment = .natural
-        nameLabel.numberOfLines = 1
+        nameLabel.numberOfLines = 0
 
         let tickLayoutGuide = UILayoutGuide()
 
@@ -72,7 +73,8 @@ final class ShoppingListCellView: UIView {
 
         let quantityLabel = UILabel()
         quantityLabel.translatesAutoresizingMaskIntoConstraints = false
-        quantityLabel.font = UIFont.systemFont(ofSize: 13)
+        quantityLabel.font = .preferredFont(forTextStyle: .footnote)
+        quantityLabel.adjustsFontForContentSizeCategory = true
         quantityLabel.textColor = .label
         quantityLabel.textAlignment = .center
         quantityLabel.numberOfLines = 1
@@ -117,8 +119,8 @@ final class ShoppingListCellView: UIView {
 
             nameLabel.leadingAnchor.constraint(equalTo: imageViewLayuotGuide.trailingAnchor, constant: 10),
             nameLabel.trailingAnchor.constraint(equalTo: tickLayoutGuide.leadingAnchor),
-            nameLabel.topAnchor.constraint(equalTo: topAnchor),
-            nameLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            nameLabel.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            nameLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
 
             checkContainer.trailingAnchor.constraint(equalTo: tickLayoutGuide.trailingAnchor).usingPriority(.defaultHigh),
             checkContainer.widthAnchor.constraint(equalToConstant: 24).usingPriority(.defaultHigh + 1),
@@ -133,7 +135,9 @@ final class ShoppingListCellView: UIView {
             quantityLabel.leadingAnchor.constraint(equalTo: tickLayoutGuide.leadingAnchor),
             quantityLabel.trailingAnchor.constraint(equalTo: checkContainer.leadingAnchor),
             quantityLabel.heightAnchor.constraint(equalToConstant: 24),
-            quantityLabel.centerYAnchor.constraint(equalTo: tickLayoutGuide.centerYAnchor)
+            quantityLabel.centerYAnchor.constraint(equalTo: tickLayoutGuide.centerYAnchor),
+
+            heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
         ])
     }
 

--- a/documentation/Changelog.md
+++ b/documentation/Changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added dynamic fonts to SepaEditViewController #Apps-231
 * Added dynamic fonts to TeleCashCreditCardEditViewController #Apps-231
 * Added dynamic fonts to SepaOverlayView #Apps-231
+* Added dynamic fonts to Scanner section #Apps-231
 
 ### Changed
 * Shopping cart indicator icons are scaled incorrectly #APPS-333


### PR DESCRIPTION
Added dynamic fonts for Scanner section:
- BarcodeEntry view
- Checkout bar
- Confirmation view
- Shopping List
- Scanner message view 

Questions:
1. Is there needed support for dynamic fonts for UISegmentedContol (Switcher between Shopping List and Shopping Cart?) It’s not system solution, but could be added

2. Should be scaled chevron down icon?
<img width="625" alt="image" src="https://user-images.githubusercontent.com/40164951/172157439-550cf919-7edc-4f5a-b3ec-074b3374627e.png">