### PR TITLE
Apps 339 scanning message fix

### DIFF
--- a/Snabble/UI/Scanner/ScanningMessageView.swift
+++ b/Snabble/UI/Scanner/ScanningMessageView.swift
@@ -49,7 +49,7 @@ final class ScanningMessageView: UIView {
 
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 2),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
         self.stackView = stackView
@@ -157,7 +157,7 @@ extension ScanningMessageView {
                 stackView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
                 stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
                 stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-                stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+                stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -35),
 
                 imageView.widthAnchor.constraint(equalToConstant: 80).usingPriority(.defaultHigh + 1),
                 imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).usingPriority(.defaultHigh + 1),

--- a/Snabble/UI/Scanner/ScanningMessageView.swift
+++ b/Snabble/UI/Scanner/ScanningMessageView.swift
@@ -70,7 +70,7 @@ final class ScanningMessageView: UIView {
     public func configure(with provider: ScanningMessageViewViewProvider) {
         let messages = provider.messages
         stackView?.removeAllArrangedSubviews()
-        for item in messages {
+        for (index, item) in messages.enumerated() {
             let view = MessageView(frame: .zero)
             if let attributedString = item.attributedString {
                 view.label?.attributedText = attributedString
@@ -83,7 +83,11 @@ final class ScanningMessageView: UIView {
                 view.imageView?.isHidden = true
             }
 
+            if index > 0 {
+                stackView?.addArrangedSubview(SeparatorView(frame: .zero))
+            }
             stackView?.addArrangedSubview(view)
+
         }
         layoutIfNeeded()
     }
@@ -92,15 +96,14 @@ final class ScanningMessageView: UIView {
         let session = Snabble.urlSession
         view.activityIndicatorView?.startAnimating()
         let task = session.dataTask(with: url) { data, _, _ in
-            defer {
-                view.activityIndicatorView?.stopAnimating()
-            }
             if let data = data, let img = UIImage(data: data) {
                 DispatchQueue.main.async {
+                    view.activityIndicatorView?.stopAnimating()
                     view.imageView?.image = img
                 }
             } else {
                 DispatchQueue.main.async {
+                    view.activityIndicatorView?.stopAnimating()
                     view.imageView?.isHidden = true
                 }
             }
@@ -118,6 +121,30 @@ final class ScanningMessageView: UIView {
 }
 
 extension ScanningMessageView {
+    final class SeparatorView: UIView {
+        override init(frame: CGRect) {
+            let view = UIView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.backgroundColor = .separator
+
+            super.init(frame: frame)
+
+            addSubview(view)
+
+            NSLayoutConstraint.activate([
+                view.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+                trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 16),
+
+                view.topAnchor.constraint(equalTo: topAnchor),
+                view.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+                bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+    }
     final class MessageView: UIView {
         private(set) weak var imageView: UIImageView?
         private(set) weak var label: UILabel?
@@ -149,10 +176,6 @@ extension ScanningMessageView {
             label.setContentHuggingPriority(.defaultLow + 1, for: .horizontal)
             label.setContentHuggingPriority(.defaultLow + 1, for: .vertical)
 
-            let separator = UIView()
-            separator.translatesAutoresizingMaskIntoConstraints = false
-            separator.backgroundColor = .separator
-
             let stackView = UIStackView(arrangedSubviews: [label, imageView])
             stackView.translatesAutoresizingMaskIntoConstraints = false
             stackView.axis = .horizontal
@@ -164,7 +187,6 @@ extension ScanningMessageView {
 
             addSubview(stackView)
             addSubview(activityIndicatorView)
-            addSubview(separator)
 
             self.imageView = imageView
             self.activityIndicatorView = activityIndicatorView
@@ -178,11 +200,6 @@ extension ScanningMessageView {
 
                 imageView.widthAnchor.constraint(equalToConstant: 80).usingPriority(.defaultHigh + 1),
                 imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).usingPriority(.defaultHigh + 1),
-
-                separator.leadingAnchor.constraint(equalTo: leadingAnchor),
-                separator.trailingAnchor.constraint(equalTo: trailingAnchor),
-                separator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
-                separator.bottomAnchor.constraint(equalTo: bottomAnchor),
 
                 activityIndicatorView.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
                 activityIndicatorView.centerXAnchor.constraint(equalTo: imageView.centerXAnchor)

--- a/Snabble/UI/Scanner/ScanningMessageView.swift
+++ b/Snabble/UI/Scanner/ScanningMessageView.swift
@@ -5,12 +5,15 @@
 //  Created by Anastasia Mishur on 29.04.22.
 //
 
+import UIKit
+
+protocol ScanningMessageViewViewProvider {
+    var messages: [ScanMessage] { get }
+}
+
 final class ScanningMessageView: UIView {
 
-    public weak var imageView: UIImageView?
-    public weak var label: UILabel?
-    public weak var spinner: UIActivityIndicatorView?
-    public var imageWidth: NSLayoutConstraint?
+    private(set) weak var stackView: UIStackView?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -18,81 +21,165 @@ final class ScanningMessageView: UIView {
     }
 
     public required init?(coder aDecoder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
+        fatalError("init(coder:) has not been implemented")
     }
 
     private func setupUI() {
         backgroundColor = .systemBackground
+
         let closeButton = UIButton(type: .custom)
         closeButton.translatesAutoresizingMaskIntoConstraints = false
         closeButton.setImage(Asset.SnabbleSDK.iconClose.image, for: .normal)
+        closeButton.isUserInteractionEnabled = false
 
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.contentMode = .scaleAspectFit
-        imageView.setContentHuggingPriority(.defaultLow + 1, for: .horizontal)
-        imageView.setContentHuggingPriority(.defaultLow + 1, for: .vertical)
-
-        let spinner = UIActivityIndicatorView()
-        spinner.translatesAutoresizingMaskIntoConstraints = false
-        spinner.hidesWhenStopped = true
-        if #available(iOS 13.0, *) {
-            spinner.style = .medium
-        } else {
-            spinner.style = .gray
-        }
-
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .preferredFont(forTextStyle: .body)
-        label.adjustsFontForContentSizeCategory = true
-        label.textColor = .label
-        label.textAlignment = .natural
-        label.numberOfLines = 0
-        label.setContentHuggingPriority(.defaultLow + 1, for: .horizontal)
-        label.setContentHuggingPriority(.defaultLow + 1, for: .vertical)
-
-        let separator = UIView()
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        separator.backgroundColor = .separator
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 0
+        stackView.distribution = .fill
+        stackView.alignment = .fill
 
         addSubview(closeButton)
-        addSubview(imageView)
-        addSubview(spinner)
-        addSubview(label)
-        addSubview(separator)
+        addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            separator.leadingAnchor.constraint(equalTo: leadingAnchor),
-            separator.trailingAnchor.constraint(equalTo: trailingAnchor),
-            separator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
-            separator.bottomAnchor.constraint(equalTo: bottomAnchor),
-
             closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 2),
             closeButton.widthAnchor.constraint(equalToConstant: 33),
-            closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            closeButton.topAnchor.constraint(equalTo: topAnchor, constant: 2),
 
-            imageView.widthAnchor.constraint(equalToConstant: 0).usingVariable(&imageWidth).usingPriority(.defaultHigh + 1),
-            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).usingPriority(.defaultHigh + 1),
-            imageView.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: 2),
-            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            imageView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 8),
-            imageView.bottomAnchor.constraint(lessThanOrEqualTo: separator.topAnchor, constant: -8),
-
-            spinner.topAnchor.constraint(equalTo: imageView.topAnchor),
-            spinner.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
-            spinner.leadingAnchor.constraint(equalTo: imageView.leadingAnchor),
-            spinner.trailingAnchor.constraint(equalTo: imageView.trailingAnchor),
-
-            label.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 16),
-            label.bottomAnchor.constraint(lessThanOrEqualTo: separator.topAnchor, constant: -16),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            label.trailingAnchor.constraint(equalTo: imageView.leadingAnchor, constant: -8)
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 2),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
+        self.stackView = stackView
+    }
 
-        self.imageView = imageView
-        self.spinner = spinner
-        self.label = label
+    public func configure(with provider: ScanningMessageViewViewProvider) {
+        let messages = provider.messages
+        stackView?.removeAllArrangedSubviews()
+        for item in messages {
+            let view = MessageView(frame: .zero)
+            if let attributedString = item.attributedString {
+                view.label?.attributedText = attributedString
+            } else {
+                view.label?.text = item.text
+            }
+            if let imgUrl = item.imageUrl, let url = URL(string: imgUrl) {
+                self.loadMessageImage(from: url, at: view)
+            } else {
+                view.imageView?.isHidden = true
+            }
+
+            stackView?.addArrangedSubview(view)
+        }
+        layoutIfNeeded()
+    }
+
+    private func loadMessageImage(from url: URL, at view: MessageView) {
+        let session = Snabble.urlSession
+        view.spinner?.startAnimating()
+        let task = session.dataTask(with: url) { data, _, _ in
+            if let data = data, let img = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    view.spinner?.stopAnimating()
+                    view.imageView?.image = img
+                }
+            } else {
+                DispatchQueue.main.async {
+                    view.spinner?.stopAnimating()
+                    view.imageView?.isHidden = true
+                }
+            }
+        }
+        task.resume()
+    }
+
+    struct Provider: ScanningMessageViewViewProvider {
+        var messages: [ScanMessage]
+
+        init(messages: [ScanMessage]) {
+            self.messages = messages
+        }
+    }
+}
+
+extension ScanningMessageView {
+    final class MessageView: UIView {
+        private(set) weak var imageView: UIImageView?
+        private(set) weak var label: UILabel?
+        private(set) weak var spinner: UIActivityIndicatorView?
+
+        override init(frame: CGRect) {
+            let imageView = UIImageView()
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            imageView.contentMode = .scaleAspectFit
+            imageView.setContentHuggingPriority(.defaultLow + 1, for: .horizontal)
+            imageView.setContentHuggingPriority(.defaultLow + 1, for: .vertical)
+
+            let spinner = UIActivityIndicatorView()
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            spinner.hidesWhenStopped = true
+            if #available(iOS 13.0, *) {
+                spinner.style = .medium
+            } else {
+                spinner.style = .gray
+            }
+
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.font = .preferredFont(forTextStyle: .body)
+            label.adjustsFontForContentSizeCategory = true
+            label.textColor = .label
+            label.textAlignment = .natural
+            label.numberOfLines = 0
+            label.setContentHuggingPriority(.defaultLow + 1, for: .horizontal)
+            label.setContentHuggingPriority(.defaultLow + 1, for: .vertical)
+
+            let separator = UIView()
+            separator.translatesAutoresizingMaskIntoConstraints = false
+            separator.backgroundColor = .separator
+
+            let stackView = UIStackView(arrangedSubviews: [label, imageView])
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+            stackView.axis = .horizontal
+            stackView.spacing = 8
+            stackView.distribution = .fill
+            stackView.alignment = .center
+
+            super.init(frame: frame)
+
+            addSubview(stackView)
+            addSubview(spinner)
+            addSubview(separator)
+
+            NSLayoutConstraint.activate([
+                stackView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+                stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+                stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+                stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+
+                imageView.widthAnchor.constraint(equalToConstant: 80).usingPriority(.defaultHigh + 1),
+                imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor).usingPriority(.defaultHigh + 1),
+
+                separator.leadingAnchor.constraint(equalTo: leadingAnchor),
+                separator.trailingAnchor.constraint(equalTo: trailingAnchor),
+                separator.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+                separator.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+                spinner.topAnchor.constraint(equalTo: imageView.topAnchor),
+                spinner.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
+                spinner.leadingAnchor.constraint(equalTo: imageView.leadingAnchor),
+                spinner.trailingAnchor.constraint(equalTo: imageView.trailingAnchor)
+            ])
+
+            self.imageView = imageView
+            self.spinner = spinner
+            self.label = label
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
     }
 }

--- a/Snabble/UI/Utilities/UIStackView+Remove.swift
+++ b/Snabble/UI/Utilities/UIStackView+Remove.swift
@@ -1,0 +1,19 @@
+//
+//  UIStackView+Remove.swift
+//  Snabble
+//
+//  Created by Anastasia Mishur on 26.07.22.
+//
+
+import Foundation
+import UIKit
+
+extension UIStackView {
+    func removeAllArrangedSubviews() {
+        arrangedSubviews.forEach { [self] view in
+            removeArrangedSubview(view)
+            NSLayoutConstraint.deactivate(view.constraints)
+            view.removeFromSuperview()
+        }
+    }
+}

--- a/documentation/Changelog.md
+++ b/documentation/Changelog.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Coupons #APPS-297
 * Added dynamic fonts to DatatransAliasViewController #APPS-231
 * Refactored DatatransAliasViewController to programmatically written UI
-* Extension UIStackView+Remove added
 * Fix for ScanMessageView and refactoring with ViewProvider pattern #APPS-339
+
+### Added
+* Extension UIStackView+Remove added
+
 
 ### Removed
 * `Gutschein` handling

--- a/documentation/Changelog.md
+++ b/documentation/Changelog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Coupons #APPS-297
 * Added dynamic fonts to DatatransAliasViewController #APPS-231
 * Refactored DatatransAliasViewController to programmatically written UI
+* Extension UIStackView+Remove added
+* Fix for ScanMessageView and refactoring with ViewProvider pattern #APPS-339
 
 ### Removed
 * `Gutschein` handling


### PR DESCRIPTION

* Extension UIStackView+Remove added
* Fix for ScanMessageView and refactoring with ViewProvider pattern #APPS-339

For possible issue with different dismission time for several messages created ticket #APPS-424.
For now business logic left as it was before (for defining dismission time by first message, and hide all messages by tapping to any of them).