### PR TITLE
add SwiftBase32 to core dependency

### DIFF
--- a/Snabble.podspec
+++ b/Snabble.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |core|
     core.source_files = 'Snabble/Core/**/*.swift'
 
+    core.dependency 'SwiftBase32', '~> 0.9.0'
     core.dependency 'GRDB.swift', '~> 5'
     core.dependency 'Zip', '~> 2'
     core.dependency 'OneTimePassword', '~> 3'

--- a/Snabble/Core/API/TokenRegistry.swift
+++ b/Snabble/Core/API/TokenRegistry.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 import OneTimePassword
-import Base32
+import SwiftBase32
 
 // backend response
 private struct AppUserResponse: Decodable {
@@ -316,7 +316,7 @@ final class TokenRegistry {
 
     private func generatePassword(_ date: Date? = nil) -> String? {
         guard
-            let secretData = MF_Base32Codec.data(fromBase32String: self.secret),
+            let secretData = SwiftBase32.base32DecodeToData(secret),
             let generator = Generator(factor: .timer(period: 30), secret: secretData, algorithm: .sha256, digits: 8)
         else {
             return nil


### PR DESCRIPTION
* replaces usage of Base32 which generates regular compiler errors
