### PR TITLE
update Image resolving via Asset

### DIFF
--- a/Snabble/UI/Utilities/Asset.swift
+++ b/Snabble/UI/Utilities/Asset.swift
@@ -39,7 +39,12 @@ public enum Asset {
         if UIImage(named: name, in: BundleToken.bundle, with: nil) != nil {
             return SwiftUI.Image(name, bundle: BundleToken.bundle)
         }
-        return SwiftUI.Image(systemName: name)
+
+        if UIImage(systemName: name) != nil {
+            return SwiftUI.Image(systemName: name)
+        }
+
+        return nil
     }
 
     public static func localizedString(forKey key: String, arguments: CVarArg..., table: String? = nil, value: String? = nil, domain: Any? = domain) -> String {


### PR DESCRIPTION
Aktuell ist das `SwiftUI.Image` an der Stelle niemals `nil`. Müssen wir nicht wie bei `Image(named:)` die Prüfung über UIKit machen, ob ein Image mit dem `systemName` vorhanden ist?

Nach meinem Verständnis haben wir aktuell einen Bug und die Anpassung behebt ihn 🤔 