### PR TITLE
Context named lookup for colors

### DIFF
--- a/Snabble/UI/ShopFinder/Views/ShopCellView.swift
+++ b/Snabble/UI/ShopFinder/Views/ShopCellView.swift
@@ -40,7 +40,7 @@ private struct Secondary: ViewModifier {
     func body(content: Content) -> some View {
         content
             .font(.subheadline)
-            .foregroundColor(.gray)
+            .foregroundColor(Color.named("Snabble.Shop.Finder.Details.foreground") ?? .gray)
     }
 }
 
@@ -48,10 +48,10 @@ private struct YouAreHere: ViewModifier {
     func body(content: Content) -> some View {
         content
            .font(.footnote)
-           .foregroundColor(Color.onAccent())
+           .foregroundColor(Color.named("Snabble.Shop.Finder.YouAreHere.foreground") ?? Color.onAccent())
            .padding(.horizontal, 8)
            .padding(.vertical, 4)
-           .background(Color.accent())
+           .background(Color.named("Snabble.Shop.Finder.YouAreHere.background") ?? Color.accent())
            .clipShape(Capsule())
     }
 }

--- a/Snabble/UI/ShopFinder/Views/ShopCellView.swift
+++ b/Snabble/UI/ShopFinder/Views/ShopCellView.swift
@@ -40,7 +40,7 @@ private struct Secondary: ViewModifier {
     func body(content: Content) -> some View {
         content
             .font(.subheadline)
-            .foregroundColor(Color.named("Snabble.Shop.Finder.Details.foreground") ?? .gray)
+            .foregroundColor(Color.named("Snabble.Shop.Finder.Secondary.foreground") ?? .gray)
     }
 }
 

--- a/Snabble/UI/Utilities/Asset+Color.swift
+++ b/Snabble/UI/Utilities/Asset+Color.swift
@@ -18,6 +18,10 @@ private extension UIColor {
 extension UIColor {
     // MARK: - Snabble Colors
 
+    public static func named(_ name: String, domain: Any? = Asset.domain) -> UIColor? {
+        Asset.color(named: name, domain: domain)
+    }
+
     public static func border(in domain: Any? = Asset.domain) -> UIColor {
         Asset.color(named: "border", domain: domain) ?? .systemGray
     }
@@ -48,6 +52,13 @@ extension SwiftUI.Color {
 
 extension SwiftUI.Color {
     // MARK: - Snabble Colors
+
+    public static func named(_ name: String, domain: Any? = Asset.domain) -> SwiftUI.Color? {
+        guard let uiColor = UIColor.named(name, domain: domain) else {
+            return nil
+        }
+        return color(uiColor)
+    }
 
     public static func border(in domain: Any? = Asset.domain) -> SwiftUI.Color {
         color(UIColor.border(in: domain))


### PR DESCRIPTION
In Teo ist mir gerade aufgefallen, das `YouAreHere` nicht im Teo Orange angezeigt wird sondern in einer anderen Farbe. Siehe [Teo - ShopFinder](https://user-images.githubusercontent.com/148758/186849660-46806a47-662b-4981-8e6f-9e8225eaf777.png).

Idee ist es mit Kontext bezogenen `String` per lookup anzufragen wo notwendig.
