### PR TITLE
Add all textStyles

### DIFF
--- a/Snabble/UI/Utilities/TextStyle.swift
+++ b/Snabble/UI/Utilities/TextStyle.swift
@@ -8,21 +8,44 @@
 import SwiftUI
 
 public enum TextStyle: String {
-    case body
-    case footnote
-    case headline
+    case largeTitle
     case title
+    case title1
+    case title2
+    case title3
+    case headline
+    case body
+    case callout
+    case subheadline
+    case footnote
+    case caption
+    case caption1
+    case caption2
 
     var font: Font {
         switch self {
-        case .body:
-            return .body
-        case .footnote:
-            return .footnote
+        case .largeTitle:
+            return .largeTitle
+        case .title, .title1:
+            return .title
+        case .title2:
+            return .title2
+        case .title3:
+            return .title3
         case .headline:
             return .headline
-        case .title:
-            return .title
+        case .body:
+            return .body
+        case .callout:
+            return .callout
+        case .subheadline:
+            return .subheadline
+        case .footnote:
+            return .footnote
+        case .caption, .caption1:
+            return .caption
+        case .caption2:
+            return .caption2
         }
     }
 }


### PR DESCRIPTION
### Besonderheit

* `title` und `title1` sind identisch. In UIKit ist es `title1` aber in SwiftUI `title`, damit es keine unerwarteten Fehler gibt würde ich empfehlen beides zu unterstützen.
* `caption` und `caption1` verhalten sich identisch zum Title.