### PR TITLE
remove dynamicViewModel in Widgets

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - AutoLayout-Helper (1.1.0)
   - Base32 (1.1.2)
   - Datatrans (2.1.0)
-  - DeviceKit (4.6.1)
+  - DeviceKit (4.7.0)
   - GRDB.swift (5.26.1):
     - GRDB.swift/standard (= 5.26.1)
   - GRDB.swift/standard (5.26.1)
@@ -64,7 +64,7 @@ SPEC CHECKSUMS:
   AutoLayout-Helper: cef12ab4c7169facf772b2afaaeecce23e898999
   Base32: 163c298644d184e89ca4e00a996bad6bf5166390
   Datatrans: 6d599ac9031b44a4688ed8e3e31f35063258072a
-  DeviceKit: 316f28290430467278b8a0d1c895968efa9e16e2
+  DeviceKit: c870c34f7c0e0ac4caa6f052e6efe7ef1472c5a1
   GRDB.swift: e98cd55ec99dea5da99355d588149063e4cfa0eb
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   OneTimePassword: c00ecc908e67e6c5bfda9d50b0b2e4696d0b066e

--- a/Snabble/UI/DynamicView/WidgetButtonView.swift
+++ b/Snabble/UI/DynamicView/WidgetButtonView.swift
@@ -14,12 +14,12 @@ private protocol WidgetButtonStyling {
 
 public struct WidgetButtonView: View {
     let widget: WidgetButton
-    @ObservedObject var viewModel: DynamicViewModel
+    let action: (WidgetButton) -> Void
     
     public var body: some View {
         HStack {
             Button(action: {
-                viewModel.actionPublisher.send(.init(widget: widget))
+                action(widget)
             }) {
                 Text(keyed: widget.text)
                     .foregroundColor(widget.foregroundColor)

--- a/Snabble/UI/DynamicView/WidgetContainer.swift
+++ b/Snabble/UI/DynamicView/WidgetContainer.swift
@@ -19,39 +19,60 @@ public struct WidgetView: View {
                 switch widget.type {
                 case .image:
                     if let widget = widget as? WidgetImage {
-                        WidgetImageView(widget: widget, viewModel: viewModel)
+                        WidgetImageView(
+                            widget: widget
+                        )
+                        .onTapGesture {
+                            viewModel.actionPublisher.send(.init(widget: widget))
+                        }
                     }
                 case .text:
                     if let widget = widget as? WidgetText {
-                        WidgetTextView(widget: widget, viewModel: viewModel)
+                        WidgetTextView(
+                            widget: widget
+                        )
+                        .onTapGesture {
+                            viewModel.actionPublisher.send(.init(widget: widget))
+                        }
                     }
                 case .button:
                     if let widget = widget as? WidgetButton {
-                        WidgetButtonView(widget: widget, viewModel: viewModel)
+                        WidgetButtonView(
+                            widget: widget
+                        ) {
+                            viewModel.actionPublisher.send(.init(widget: $0))
+                        }
                     }
                 case .information:
                     if let widget = widget as? WidgetInformation {
-                        WidgetInformationView(widget: widget, viewModel: viewModel)
+                        WidgetInformationView(
+                            widget: widget,
+                            shadowRadius: viewModel.configuration.shadowRadius
+                        )
+                        .onTapGesture {
+                            viewModel.actionPublisher.send(.init(widget: widget))
+                        }
                     }
                 case .purchases:
                     if let widget = widget as? WidgetPurchase {
                         WidgetPurchasesView(
                             widget: widget,
-                            viewModel: viewModel
+                            shadowRadius: viewModel.configuration.shadowRadius,
+                            action: {
+                                viewModel.actionPublisher.send($0)
+                            }
                         )
                     }
                 case .toggle:
                     if let widget = widget as? WidgetToggle {
-                        WidgetToggleView(widget: widget, viewModel: viewModel)
-                    }
-                case .locationPermission:
-                    if let widget = widget as? WidgetLocationPermission {
-                        WidgetLocationPermissionView(
+                        WidgetToggleView(
                             widget: widget,
-                            viewModel: viewModel
+                            action: {
+                                viewModel.actionPublisher.send($0)
+                            }
                         )
                     }
-                case .section:
+                case .section, .locationPermission:
                     EmptyView()
                 }
                 if let spacing = widget.spacing ?? viewModel.configuration.spacing {

--- a/Snabble/UI/DynamicView/WidgetImageView.swift
+++ b/Snabble/UI/DynamicView/WidgetImageView.swift
@@ -9,12 +9,8 @@ import SwiftUI
 
 public struct WidgetImageView: View {
     let widget: WidgetImage
-    @ObservedObject var viewModel: DynamicViewModel
 
     public var body: some View {
         widget.image
-            .onTapGesture {
-                viewModel.actionPublisher.send(.init(widget: widget))
-            }
     }
 }

--- a/Snabble/UI/DynamicView/WidgetInformationView.swift
+++ b/Snabble/UI/DynamicView/WidgetInformationView.swift
@@ -26,7 +26,7 @@ extension View {
 
 public struct WidgetInformationView: View {
     let widget: WidgetInformation
-    @ObservedObject var viewModel: DynamicViewModel
+    let shadowRadius: CGFloat
 
     public var body: some View {
         HStack(alignment: .top) {
@@ -36,9 +36,6 @@ public struct WidgetInformationView: View {
             Spacer()
         }
         .informationStyle()
-        .onTapGesture {
-            viewModel.actionPublisher.send(.init(widget: widget))
-        }
-        .shadow(radius: viewModel.configuration.shadowRadius)
+        .shadow(radius: shadowRadius)
     }
 }

--- a/Snabble/UI/DynamicView/WidgetPurchasesView.swift
+++ b/Snabble/UI/DynamicView/WidgetPurchasesView.swift
@@ -73,7 +73,6 @@ public struct WidgetPurchasesView: View {
     let action: (DynamicAction) -> Void
     let shadowRadius: CGFloat
 
-//    @ObservedObject var dynamicViewModel: DynamicViewModel
     @ObservedObject private var viewModel: PurchasesViewModel
 
     init(widget: WidgetPurchase, shadowRadius: CGFloat, action: @escaping (DynamicAction) -> Void) {

--- a/Snabble/UI/DynamicView/WidgetPurchasesView.swift
+++ b/Snabble/UI/DynamicView/WidgetPurchasesView.swift
@@ -70,13 +70,16 @@ class PurchasesViewModel: ObservableObject, LoadableObject {
 
 public struct WidgetPurchasesView: View {
     let widget: Widget
+    let action: (DynamicAction) -> Void
+    let shadowRadius: CGFloat
 
-    @ObservedObject var dynamicViewModel: DynamicViewModel
-    @ObservedObject var viewModel: PurchasesViewModel
+//    @ObservedObject var dynamicViewModel: DynamicViewModel
+    @ObservedObject private var viewModel: PurchasesViewModel
 
-    init(widget: WidgetPurchase, viewModel dynamicViewModel: DynamicViewModel) {
+    init(widget: WidgetPurchase, shadowRadius: CGFloat, action: @escaping (DynamicAction) -> Void) {
         self.widget = widget
-        self.dynamicViewModel = dynamicViewModel
+        self.action = action
+        self.shadowRadius = shadowRadius
         self.viewModel = PurchasesViewModel(projectId: widget.projectId)
     }
     
@@ -87,7 +90,7 @@ public struct WidgetPurchasesView: View {
                     Text(keyed: output.title)
                     Spacer()
                     Button(action: {
-                        dynamicViewModel.actionPublisher.send(.init(widget: widget))
+                        action(.init(widget: widget))
                     }) {
                             Text(keyed: "Snabble.DynamicView.LastPurchases.all")
                     }
@@ -98,9 +101,9 @@ public struct WidgetPurchasesView: View {
                             provider: provider,
                             projectId: viewModel.projectId
                         ).onTapGesture {
-                            dynamicViewModel.actionPublisher.send(.init(widget: widget, userInfo: ["id": provider.id]))
+                            action(.init(widget: widget, userInfo: ["id": provider.id]))
                         }
-                        .shadow(radius: dynamicViewModel.configuration.shadowRadius)
+                        .shadow(radius: shadowRadius)
                     }
                 }
             }

--- a/Snabble/UI/DynamicView/WidgetTextView.swift
+++ b/Snabble/UI/DynamicView/WidgetTextView.swift
@@ -32,7 +32,6 @@ private struct NavigationWidget: ViewModifier {
 
 public struct WidgetTextView: View {
     var widget: WidgetText
-    @ObservedObject var viewModel: DynamicViewModel
 
     public var body: some View {
         HStack {
@@ -42,9 +41,6 @@ public struct WidgetTextView: View {
             Spacer()
         }
         .modifier(NavigationWidget(text: Asset.localizedString(forKey: widget.text), active: widget.showDisclosure ?? false))
-        .onTapGesture {
-            viewModel.actionPublisher.send(.init(widget: widget))
-        }
     }
 }
 

--- a/Snabble/UI/DynamicView/WidgetToggle.swift
+++ b/Snabble/UI/DynamicView/WidgetToggle.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 public struct WidgetToggleView: View {
     var widget: WidgetToggle
-    @ObservedObject var viewModel: DynamicViewModel
+    var action: (DynamicAction) -> Void
     @AppStorage var value: Bool
 
-    init(widget: WidgetToggle, viewModel: DynamicViewModel) {
+    init(widget: WidgetToggle, action: @escaping (DynamicAction) -> Void) {
         self.widget = widget
-        self.viewModel = viewModel
+        self.action = action
 
         self._value = AppStorage(
             wrappedValue: UserDefaults.standard.bool(forKey: widget.key), widget.key,
@@ -27,12 +27,10 @@ public struct WidgetToggleView: View {
             Toggle(Asset.localizedString(forKey: widget.text), isOn: $value)
         }
         .onChange(of: value) { newState in
-            viewModel.actionPublisher.send(
-                .init(
-                    widget: widget,
-                    userInfo: [widget.key: newState]
-                )
-            )
+            action(.init(
+                widget: widget,
+                userInfo: [widget.key: newState]
+            ))
         }
     }
 }


### PR DESCRIPTION
* add `action()` Method if needed for widgets
* uses `tapGesture` for simple widgets
* removes reference of @ObservedObject of dynamicViewModel in widgets

Wir brauchen die Möglichkeit mit der Action für die intelligenten Widgets die beispielsweise das ButtonWidget verwenden, da ansonsten die Aktion nur über den Publisher an die HostedApp weitergeleitet werden kann.
