### PR TITLE
feat(Receipts): Persistent archive index and offline receipt browsing

### DIFF
--- a/AssetProviding/Sources/Resources/de.lproj/Localizable.strings
+++ b/AssetProviding/Sources/Resources/de.lproj/Localizable.strings
@@ -286,9 +286,8 @@
 "Snabble.Receipt.reportProblem" = "Problem Melden";
 "Snabble.Receipt.share" = "Teilen";
 "Snabble.Receipts.Archive.create" = "Erstelle Archiv";
-"Snabble.Receipts.Archive.created" = "Archiv erstellt";
 "Snabble.Receipts.Archive.failed" = "Archivierung fehlgeschlagen";
-"Snabble.Receipts.Archive.ordersArchived" = "%ld Beleg(e) archiviert";
+"Snabble.Receipts.Archive.listTitle" = "Archiv";
 "Snabble.Receipts.Archive.retry" = "Erneut versuchen";
 "Snabble.Receipts.Archive.share" = "Archiv Teilen";
 "Snabble.Receipts.Archive.start" = "Archiviere Deine Belege";

--- a/AssetProviding/Sources/Resources/en.lproj/Localizable.strings
+++ b/AssetProviding/Sources/Resources/en.lproj/Localizable.strings
@@ -286,9 +286,8 @@
 "Snabble.Receipt.reportProblem" = "Report Problem";
 "Snabble.Receipt.share" = "Share";
 "Snabble.Receipts.Archive.create" = "Create Archive";
-"Snabble.Receipts.Archive.created" = "Archive created";
 "Snabble.Receipts.Archive.failed" = "Archive Failed";
-"Snabble.Receipts.Archive.ordersArchived" = "%ld  order(s) archive";
+"Snabble.Receipts.Archive.listTitle" = "Archive";
 "Snabble.Receipts.Archive.retry" = "Try Again";
 "Snabble.Receipts.Archive.share" = "Share Archive";
 "Snabble.Receipts.Archive.start" = "Archive your Receipts";

--- a/AssetProviding/Sources/Resources/fr-CH.lproj/Localizable.strings
+++ b/AssetProviding/Sources/Resources/fr-CH.lproj/Localizable.strings
@@ -286,9 +286,8 @@
 "Snabble.Receipt.reportProblem" = "Report Problem";
 "Snabble.Receipt.share" = "Share";
 "Snabble.Receipts.Archive.create" = "Create Archive";
-"Snabble.Receipts.Archive.created" = "Archive created";
 "Snabble.Receipts.Archive.failed" = "Archive Failed";
-"Snabble.Receipts.Archive.ordersArchived" = "%ld  order(s) archive";
+"Snabble.Receipts.Archive.listTitle" = "Archive";
 "Snabble.Receipts.Archive.retry" = "Try Again";
 "Snabble.Receipts.Archive.share" = "Share Archive";
 "Snabble.Receipts.Archive.start" = "Archive your Receipts";

--- a/AssetProviding/Sources/Resources/fr.lproj/Localizable.strings
+++ b/AssetProviding/Sources/Resources/fr.lproj/Localizable.strings
@@ -286,9 +286,8 @@
 "Snabble.Receipt.reportProblem" = "Report Problem";
 "Snabble.Receipt.share" = "Share";
 "Snabble.Receipts.Archive.create" = "Create Archive";
-"Snabble.Receipts.Archive.created" = "Archive created";
 "Snabble.Receipts.Archive.failed" = "Archive Failed";
-"Snabble.Receipts.Archive.ordersArchived" = "%ld  order(s) archive";
+"Snabble.Receipts.Archive.listTitle" = "Archive";
 "Snabble.Receipts.Archive.retry" = "Try Again";
 "Snabble.Receipts.Archive.share" = "Share Archive";
 "Snabble.Receipts.Archive.start" = "Archive your Receipts";

--- a/AssetProviding/Sources/Resources/hu.lproj/Localizable.strings
+++ b/AssetProviding/Sources/Resources/hu.lproj/Localizable.strings
@@ -286,9 +286,8 @@
 "Snabble.Receipt.reportProblem" = "Report Problem";
 "Snabble.Receipt.share" = "Share";
 "Snabble.Receipts.Archive.create" = "Create Archive";
-"Snabble.Receipts.Archive.created" = "Archive created";
 "Snabble.Receipts.Archive.failed" = "Archive Failed";
-"Snabble.Receipts.Archive.ordersArchived" = "%ld  order(s) archive";
+"Snabble.Receipts.Archive.listTitle" = "Archive";
 "Snabble.Receipts.Archive.retry" = "Try Again";
 "Snabble.Receipts.Archive.share" = "Share Archive";
 "Snabble.Receipts.Archive.start" = "Archive your Receipts";

--- a/AssetProviding/Sources/Resources/it.lproj/Localizable.strings
+++ b/AssetProviding/Sources/Resources/it.lproj/Localizable.strings
@@ -286,9 +286,8 @@
 "Snabble.Receipt.reportProblem" = "Report Problem";
 "Snabble.Receipt.share" = "Share";
 "Snabble.Receipts.Archive.create" = "Create Archive";
-"Snabble.Receipts.Archive.created" = "Archive created";
 "Snabble.Receipts.Archive.failed" = "Archive Failed";
-"Snabble.Receipts.Archive.ordersArchived" = "%ld  order(s) archive";
+"Snabble.Receipts.Archive.listTitle" = "Archive";
 "Snabble.Receipts.Archive.retry" = "Try Again";
 "Snabble.Receipts.Archive.share" = "Share Archive";
 "Snabble.Receipts.Archive.start" = "Archive your Receipts";

--- a/AssetProviding/Sources/Resources/sk.lproj/Localizable.strings
+++ b/AssetProviding/Sources/Resources/sk.lproj/Localizable.strings
@@ -286,9 +286,8 @@
 "Snabble.Receipt.reportProblem" = "Report Problem";
 "Snabble.Receipt.share" = "Share";
 "Snabble.Receipts.Archive.create" = "Create Archive";
-"Snabble.Receipts.Archive.created" = "Archive created";
 "Snabble.Receipts.Archive.failed" = "Archive Failed";
-"Snabble.Receipts.Archive.ordersArchived" = "%ld  order(s) archive";
+"Snabble.Receipts.Archive.listTitle" = "Archive";
 "Snabble.Receipts.Archive.retry" = "Try Again";
 "Snabble.Receipts.Archive.share" = "Share Archive";
 "Snabble.Receipts.Archive.start" = "Archive your Receipts";

--- a/Core/Sources/API/SDKVersion.swift
+++ b/Core/Sources/API/SDKVersion.swift
@@ -5,5 +5,5 @@
 //
 
 public var SDKVersion: String {
-    "1.0.3"
+    "1.0.4"
 }

--- a/Example/Mintfile
+++ b/Example/Mintfile
@@ -1,2 +1,2 @@
-realm/SwiftLint@0.63.2
-mono0926/LicensePlist@3.27.8
+realm/SwiftLint@0.64.1
+mono0926/LicensePlist@3.27.9

--- a/Example/com.mono0926.LicensePlist.Output/com.mono0926.LicensePlist.latest_result.txt
+++ b/Example/com.mono0926.LicensePlist.Output/com.mono0926.LicensePlist.latest_result.txt
@@ -1,6 +1,6 @@
-name: LicensePlist, nameSpecified: , owner: mono0926, version: 3.27.8, source: https://github.com/mono0926/LicensePlist
+name: LicensePlist, nameSpecified: , owner: mono0926, version: 3.27.9, source: https://github.com/mono0926/LicensePlist
 
-name: SwiftLint, nameSpecified: , owner: realm, version: 0.63.2, source: https://github.com/realm/SwiftLint
+name: SwiftLint, nameSpecified: , owner: realm, version: 0.64.1, source: https://github.com/realm/SwiftLint
 
 name: CameraZoomWheel, nameSpecified: CameraZoomWheel, owner: utilem, version: 2.0.0, source: https://github.com/utilem/CameraZoomWheel
 
@@ -30,4 +30,4 @@ name: ZIPFoundation, nameSpecified: ZIPFoundation, owner: weichsel, version: 0.9
 
 add-version-numbers: false
 
-LicensePlist Version: 3.27.8
+LicensePlist Version: 3.27.9

--- a/Example/com.mono0926.LicensePlist.Output/com.mono0926.LicensePlist/ios-sdk.plist
+++ b/Example/com.mono0926.LicensePlist.Output/com.mono0926.LicensePlist/ios-sdk.plist
@@ -6,32 +6,7 @@
 	<array>
 		<dict>
 			<key>FooterText</key>
-			<string>
-
-Datatrans iOS SDK uses code from the following open source libraries:
-
-- GData
-
-
-Licenses:
-
-*  GData (Apache 2.0 License)
-GData.framework is developed by Google and licensed under the following Apache License:
-_____________________________________________________________________
-
-Copyright (c) 2007 Google Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
- http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.</string>
+			<string></string>
 			<key>License</key>
 			<string>unknown</string>
 			<key>Type</key>

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-realm/SwiftLint@0.63.2
-mono0926/LicensePlist@3.27.7
+realm/SwiftLint@0.64.1
+mono0926/LicensePlist@3.27.9

--- a/Receipts/Sources/ArchiveListScreen.swift
+++ b/Receipts/Sources/ArchiveListScreen.swift
@@ -1,0 +1,59 @@
+//
+//  ArchiveListScreen.swift
+//
+//  Created by Uwe Tilemann on 25.06.26.
+//
+
+import SwiftUI
+
+import SnabbleCore
+import SnabbleAssetProviding
+import SnabbleComponents
+
+/// Shows the locally archived receipts loaded from the `.index.json` manifest.
+public struct ArchiveListScreen: View {
+
+    @State private var viewModel = PurchasesViewModel()
+
+    public init() {}
+
+    public var body: some View {
+        AsyncContentView(source: viewModel, content: { output in
+            List(output, id: \.id) { provider in
+                let pdfURL = OrderArchiveManager.archivedReceiptURL(for: provider as! Order)
+                if FileManager.default.fileExists(atPath: pdfURL.path) {
+                    NavigationLink {
+                        ReceiptDetailScreen(localURL: pdfURL, provider: provider)
+                    } label: {
+                        ReceiptsItemView(
+                            provider: provider,
+                            image: viewModel.imageFor(projectId: provider.projectId),
+                            showReadState: !viewModel.isRead(receiptId: provider.id),
+                            showChevron: false
+                        )
+                    }
+                    .onAppear {
+                        viewModel.markAsRead(receiptId: provider.id)
+                    }
+                } else {
+                    ReceiptsItemView(
+                        provider: provider,
+                        image: viewModel.imageFor(projectId: provider.projectId),
+                        showReadState: false,
+                        showChevron: false
+                    )
+                }
+            }
+            .listStyle(.plain)
+        }, empty: {
+            ContentUnavailableView(
+                Asset.localizedString(forKey: "Snabble.Receipts.noReceipts"),
+                systemImage: "archivebox"
+            )
+        })
+        .navigationTitle(Asset.localizedString(forKey: "Snabble.Receipts.Archive.listTitle"))
+        .task {
+            viewModel.loadFromArchive()
+        }
+    }
+}

--- a/Receipts/Sources/ArchiveReceiptsView.swift
+++ b/Receipts/Sources/ArchiveReceiptsView.swift
@@ -1,7 +1,7 @@
 //
 //  ArchiveReceiptsView.swift
 //
-//  Copyright © 2026 snabble. All rights reserved.
+//  Created by Uwe Tilemann on 25.06.26.
 //
 
 import SwiftUI
@@ -36,12 +36,14 @@ public struct ArchiveReceiptsView: View {
     public var body: some View {
         NavigationStack {
             content
-                .navigationTitle(Asset.localizedString(forKey: "Snabble.Receipts.Archive.title")) // Archive Receipts
+                .navigationTitle(Asset.localizedString(forKey: "Snabble.Receipts.Archive.listTitle")) // Archive Receipts
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar { toolbarContent }
-                .task { if silent {
-                    viewModel.startArchive(orders: orders)
-                }}
+                .task {
+                    if silent {
+                        viewModel.startArchive(orders: orders)
+                    }
+                }
         }
     }
 
@@ -113,31 +115,18 @@ public struct ArchiveReceiptsView: View {
     }
 
     private func doneView(url: URL) -> some View {
-        VStack(spacing: 24) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 56))
-                .foregroundStyle(.green)
-
-            Text(Asset.localizedString(forKey: "Snabble.Receipts.Archive.created")) // "Archive Created"
-                .font(.title2.bold())
-            Text(Asset.localizedString(forKey: "Snabble.Receipts.Archive.ordersArchived", arguments: orders.count)) // \(orders.count) order(s) archived.
-            
-            if !silent {
-                Button {
-                    showShareSheet = true
-                } label: {
-                    Label(Asset.localizedString(forKey: "Snabble.Receipts.Archive.share"), systemImage: "square.and.arrow.up") // "Share Archive"
-                }
-                .buttonStyle(ProjectPrimaryButtonStyle())
-                .sheet(isPresented: $showShareSheet) {
-                    ArchiveShareSheet(url: url)
-                }
+        VStack {
+            ArchiveListScreen()
+            Button {
+                showShareSheet = true
+            } label: {
+                Label(Asset.localizedString(forKey: "Snabble.Receipts.Archive.share"), systemImage: "square.and.arrow.up") // "Share Archive"
+                    .frame(maxWidth: .infinity)
             }
-        }
-        .task {
-            if silent {
-                try? await Task.sleep(for: .seconds(1))
-                dismiss()
+            .padding(.horizontal)
+            .buttonStyle(ProjectPrimaryButtonStyle())
+            .sheet(isPresented: $showShareSheet) {
+                ArchiveShareSheet(url: url)
             }
         }
 #if DEBUG
@@ -145,7 +134,6 @@ public struct ArchiveReceiptsView: View {
             print("archived url: \(url)")
         }
 #endif
-        .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 

--- a/Receipts/Sources/Models/ArchiveReceiptsViewModel.swift
+++ b/Receipts/Sources/Models/ArchiveReceiptsViewModel.swift
@@ -1,7 +1,7 @@
 //
 //  ArchiveReceiptsViewModel.swift
 //
-//  Copyright © 2026 snabble. All rights reserved.
+//  Created by Uwe Tilemann on 25.06.26.
 //
 
 import Foundation

--- a/Receipts/Sources/Models/OrderArchiveManager.swift
+++ b/Receipts/Sources/Models/OrderArchiveManager.swift
@@ -39,9 +39,10 @@ public enum OrderArchiveError: LocalizedError {
 public struct OrderArchiveManager {
 
     /// Downloads all receipts from `orders` into a new folder
-    /// named "Order Archive-yyyy-MM-dd" in the Documents directory.
+    /// named \"Order Archive\" in the Documents directory.
     /// Within that folder each shop gets its own subdirectory and
     /// each file is named by the unique order id.
+    /// A hidden `.index.json` containing all archived orders is written to the archive root.
     ///
     /// - Parameters:
     ///   - orders: The orders to archive. Orders without a receipt link are skipped.
@@ -93,10 +94,21 @@ public struct OrderArchiveManager {
         guard succeeded > 0 else {
             throw OrderArchiveError.noReceiptsDownloaded
         }
+
+        try writeIndex(receipts, to: archiveURL)
+
         return archiveURL
     }
 
     // MARK: - Private helpers
+
+    private static func writeIndex(_ orders: [Order], to archiveURL: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(orders)
+        let indexURL = archiveURL.appendingPathComponent(".index.json")
+        try data.write(to: indexURL, options: .atomic)
+    }
 
     private static func makeArchiveDirectory() throws -> URL {
         let docsURL = try FileManager.default.url(

--- a/Receipts/Sources/Models/OrderArchiveManager.swift
+++ b/Receipts/Sources/Models/OrderArchiveManager.swift
@@ -38,6 +38,37 @@ public enum OrderArchiveError: LocalizedError {
 @MainActor
 public struct OrderArchiveManager {
 
+    // MARK: - Public helpers
+
+    /// Root folder of the receipt archive in the app's Documents directory.
+    public static var archiveDirectoryURL: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Order Archive", isDirectory: true)
+    }
+
+    /// `true` when a valid archive index exists on disk.
+    public static var hasArchive: Bool {
+        FileManager.default.fileExists(atPath: archiveIndexURL.path)
+    }
+
+    /// Loads all orders stored in the archive index.
+    public static func loadIndex() throws -> [Order] {
+        let data = try Data(contentsOf: archiveIndexURL)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode([Order].self, from: data)
+    }
+
+    /// Returns the expected local PDF URL for an archived order.
+    /// The file may not exist if the PDF failed to download during archiving.
+    public static func archivedReceiptURL(for order: Order) -> URL {
+        archiveDirectoryURL
+            .appendingPathComponent(sanitized(order.shopName), isDirectory: true)
+            .appendingPathComponent("\(order.id).pdf")
+    }
+
+    // MARK: - Archive creation
+
     /// Downloads all receipts from `orders` into a new folder
     /// named \"Order Archive\" in the Documents directory.
     /// Within that folder each shop gets its own subdirectory and
@@ -102,24 +133,20 @@ public struct OrderArchiveManager {
 
     // MARK: - Private helpers
 
+    private static var archiveIndexURL: URL {
+        archiveDirectoryURL.appendingPathComponent(".index.json")
+    }
+
     private static func writeIndex(_ orders: [Order], to archiveURL: URL) throws {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(orders)
-        let indexURL = archiveURL.appendingPathComponent(".index.json")
-        try data.write(to: indexURL, options: .atomic)
+        try data.write(to: archiveIndexURL, options: .atomic)
     }
 
     private static func makeArchiveDirectory() throws -> URL {
-        let docsURL = try FileManager.default.url(
-            for: .documentDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        let archiveURL = docsURL.appendingPathComponent("Order Archive", isDirectory: true)
-        try FileManager.default.createDirectory(at: archiveURL, withIntermediateDirectories: true)
-        return archiveURL
+        try FileManager.default.createDirectory(at: archiveDirectoryURL, withIntermediateDirectories: true)
+        return archiveDirectoryURL
     }
 
     /// Returns (creating if needed) a per-shop subdirectory inside `archiveURL`.

--- a/Receipts/Sources/Models/PurchasesViewModel.swift
+++ b/Receipts/Sources/Models/PurchasesViewModel.swift
@@ -202,3 +202,17 @@ extension PurchasesViewModel {
         }
     }
 }
+
+extension PurchasesViewModel {
+    /// Loads receipts from the local archive index instead of the network.
+    @MainActor
+    public func loadFromArchive() {
+        do {
+            let orders = try OrderArchiveManager.loadIndex()
+            state = orders.isEmpty ? .empty : .loaded(orders)
+            updateUnreadCount()
+        } catch {
+            state = .failed(error)
+        }
+    }
+}

--- a/Receipts/Sources/ReceiptDetailScreen.swift
+++ b/Receipts/Sources/ReceiptDetailScreen.swift
@@ -2,7 +2,7 @@
 //  ReceiptDetailScreen.swift
 //  Snabble
 //
-//  Copyright © 2026 snabble. All rights reserved.
+//  Created by Uwe Tilemann on 11.03.26.
 //
 
 import SwiftUI
@@ -16,6 +16,7 @@ import SnabbleAssetProviding
 public struct ReceiptDetailScreen: View {
     let orderId: String
     let projectId: Identifier<Project>
+    private let localURL: URL?
 
     @State private var receiptURL: URL?
     @State private var supportEmail: String?
@@ -29,11 +30,23 @@ public struct ReceiptDetailScreen: View {
     public init(orderId: String, projectId: Identifier<Project>) {
         self.orderId = orderId
         self.projectId = projectId
+        self.localURL = nil
     }
 
     public init(provider: any PurchaseProviding) {
         self.orderId = provider.id
         self.projectId = provider.projectId
+        self.localURL = nil
+    }
+
+    /// Init for archived receipts — skips server download and shows the local PDF directly.
+    public init(localURL: URL, provider: any PurchaseProviding) {
+        self.localURL = localURL
+        self.orderId = provider.id
+        self.projectId = provider.projectId
+        self._receiptURL = State(initialValue: localURL)
+        self._isLoading = State(initialValue: false)
+        self._order = State(initialValue: order)
     }
 
     public var body: some View {
@@ -50,6 +63,7 @@ public struct ReceiptDetailScreen: View {
                 ReceiptPreviewView(url: receiptURL)
             }
         }
+        .navigationTitle(order?.dateString ?? "")
         .toolbar {
             if receiptURL != nil {
                 ToolbarItem(placement: .navigationBarTrailing) {
@@ -84,7 +98,7 @@ public struct ReceiptDetailScreen: View {
             if let url = receiptURL {
                 MailComposerViewController(
                     recipients: supportEmail != nil ? [supportEmail!] : [],
-                    subject: Asset.localizedString(forKey:"Snabble.Receipt.Mail.subject"), // "Receipt Problem Report"
+                    subject: Asset.localizedString(forKey:"Snabble.Receipt.Mail.subject"),
                     messageBody: mailBody(),
                     url: url
                 )
@@ -93,7 +107,7 @@ public struct ReceiptDetailScreen: View {
         .alert(Asset.localizedString(forKey:"Snabble.Receipt.Mail.notAvailable"), isPresented: $showMailUnavailableAlert) {
             Button("OK", role: .cancel) { }
         } message: {
-            Text(Asset.localizedString(forKey: "Snabble.Receipt.Mail.configure")) // "Please configure a mail account in Settings to send problem reports."
+            Text(Asset.localizedString(forKey: "Snabble.Receipt.Mail.configure"))
         }
         .task {
             await loadReceipt()
@@ -101,27 +115,24 @@ public struct ReceiptDetailScreen: View {
     }
     
     private func mailBody() -> String {
-        var body = Asset.localizedString(forKey: "Snabble.Receipt.Mail.header") // "I would like to report a problem with this receipt.\n\n"
+        var body = Asset.localizedString(forKey: "Snabble.Receipt.Mail.header")
         
         if let order = order {
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
             formatter.timeStyle = .short
-            body += Asset.localizedString(
-                forKey: "Snabble.Receipt.Mail.orderId", // "Order ID: \(order.id)\n"
-                arguments: order.id
-            )
-            body += Asset.localizedString(
-                forKey: "Snabble.Receipt.Mail.orderDate",
-                arguments: formatter.string(from: order.date) // "Date: \(formatter.string(from: order.date))\n\n"
-            )
+            body += Asset.localizedString(forKey: "Snabble.Receipt.Mail.orderId", arguments: order.id)
+            body += Asset.localizedString(forKey: "Snabble.Receipt.Mail.orderDate", arguments: formatter.string(from: order.date))
         }
-        body += Asset.localizedString(forKey: "Snabble.Receipt.Mail.body") // "Please describe the problem:\n\n"
+        body += Asset.localizedString(forKey: "Snabble.Receipt.Mail.body")
 
         return body
     }
     
     private func loadReceipt() async {
+        // Local archive receipts are already set via init — skip server download.
+        guard localURL == nil else { return }
+
         guard let project = Snabble.shared.project(for: projectId) ?? Snabble.shared.projects.first else {
             self.error = ReceiptError.missingProject
             self.isLoading = false
@@ -273,4 +284,3 @@ struct MailComposerViewController: UIViewControllerRepresentable {
         }
     }
 }
-

--- a/Receipts/Sources/ReceiptsListScreen.swift
+++ b/Receipts/Sources/ReceiptsListScreen.swift
@@ -91,6 +91,10 @@ public struct ReceiptsListScreen<SomeEmptyView: View>: View {
     @ViewBuilder let placeholderView: SomeEmptyView
     
     @State private var showArchive = false
+    @State private var archiveExists = false
+
+    // Temporary disabled feature
+    private let archiveAvailable: Bool = false
     
     public init(model: PurchasesViewModel = .init(), useBuiltInNavigation: Bool = true) {
         self._viewModel = State(initialValue: model)
@@ -132,10 +136,33 @@ public struct ReceiptsListScreen<SomeEmptyView: View>: View {
         }
     }
     
+    @ViewBuilder
+    private var archiveListItemView: some View {
+        if archiveAvailable, archiveExists {
+            Section {
+                NavigationLink {
+                    ArchiveListScreen()
+                } label: {
+                    Label {
+                        Text(Asset.localizedString(forKey: "Snabble.Receipts.Archive.listTitle"))
+                            .font(.headline)
+                    } icon: {
+                        Image(systemName: "archivebox.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .foregroundColor(.projectPrimary())
+                            .frame(width: 60)
+                    }
+                }
+            }
+        }
+    }
+    
     public var body: some View {
         AsyncContentView(source: viewModel, content: { output in
             VStack {
                 List {
+                    archiveListItemView
                     ForEach(output, id: \.combinedID) { provider in
                         receiptRow(for: provider)
                             .contextMenu {
@@ -164,9 +191,13 @@ public struct ReceiptsListScreen<SomeEmptyView: View>: View {
         }
         .sheet(isPresented: $showArchive) {
             archiveView
+                .onDisappear {
+                    archiveExists = OrderArchiveManager.hasArchive
+                }
                 .presentationDetents([.medium, .large])
         }
         .task {
+            archiveExists = OrderArchiveManager.hasArchive
             viewModel.reset()
         }
         .toolbar {


### PR DESCRIPTION
After archiving receipts, a hidden .index.json manifest is now written to the archive directory. This enables browsing archived receipts offline without a server connection.

Changes:

• OrderArchiveManager: Added public helpers (archiveDirectoryURL, hasArchive, loadIndex(), archivedReceiptURL(for:)) and writes a .index.json manifest after every archive run. The archive folder is now always named Order Archive (fixed, was previously date-suffixed).
• ArchiveListScreen (new): Reads the index and displays locally archived receipts. Each item navigates to ReceiptDetailScreen using the local PDF file directly.
• ArchiveReceiptsView: After a successful archive, shows ArchiveListScreen with a share button instead of the old success splash screen.
• ReceiptDetailScreen: New init(localURL:provider:) that skips the server download and renders the local PDF immediately.
• PurchasesViewModel: New loadFromArchive() method that populates the view from the local index instead of the network.
• ReceiptsListScreen: Adds an archive entry point in the list (guarded by archiveAvailable = false — temporarily disabled until the feature is ready).