### PR TITLE
Fix Apple Pay checkout navigation in SwiftUI #Apps-2667

### DIFF
--- a/Components/Sources/SwiftUI/View/ContainerView.swift
+++ b/Components/Sources/SwiftUI/View/ContainerView.swift
@@ -18,8 +18,28 @@ public struct ContainerView: UIViewControllerRepresentable {
         return ContainerViewController(viewController: viewController)
     }
     
-    // swiftlint:disable:next no_empty_block
-    public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+    public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        guard let container = uiViewController as? ContainerViewController,
+              container.viewController !== viewController else { return }
+
+        // Replace the hosted view controller in place (e.g. ApplePayVC → CheckoutStepsVC).
+        let old = container.viewController
+        old.willMove(toParent: nil)
+        old.view.removeFromSuperview()
+        old.removeFromParent()
+
+        container.addChild(viewController)
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+        container.view.addSubview(viewController.view)
+        viewController.didMove(toParent: container)
+
+        NSLayoutConstraint.activate([
+            viewController.view.leadingAnchor.constraint(equalTo: container.view.leadingAnchor),
+            viewController.view.trailingAnchor.constraint(equalTo: container.view.trailingAnchor),
+            viewController.view.topAnchor.constraint(equalTo: container.view.topAnchor),
+            viewController.view.bottomAnchor.constraint(equalTo: container.view.bottomAnchor)
+        ])
+    }
     
     class ContainerViewController: UIViewController {
         public let viewController: UIViewController

--- a/Core/Sources/API/SDKVersion.swift
+++ b/Core/Sources/API/SDKVersion.swift
@@ -5,5 +5,5 @@
 //
 
 public var SDKVersion: String {
-    "1.1.0"
+    "1.1.1"
 }

--- a/Payment/Sources/ApplePay/ApplePayCheckoutViewController.swift
+++ b/Payment/Sources/ApplePay/ApplePayCheckoutViewController.swift
@@ -16,6 +16,7 @@ final class ApplePayCheckoutViewController: UIViewController {
     private let countryCode: String?
     private var authorized = false
     private var poller: PaymentProcessPoller?
+    private var applePayStarted = false
     
     private let checkoutProcess: CheckoutProcess
     private let shoppingCart: ShoppingCart
@@ -52,9 +53,16 @@ final class ApplePayCheckoutViewController: UIViewController {
         self.navigationItem.hidesBackButton = true
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // Guard against re-entry when the Apple Pay sheet is dismissed and viewDidAppear fires again.
+        // Must run in viewDidAppear (not viewWillAppear) so the VC is fully in the window hierarchy
+        // when embedded as a child inside SwiftUI's ContainerView — presenting from a "detached"
+        // view controller corrupts the root presentation and leaves navigationController nil.
+        guard !applePayStarted else { return }
+        applePayStarted = true
+
         if let applePayAuth = createApplePayProcessor(for: checkoutProcess) {
             self.authController = applePayAuth
             self.present(applePayAuth, animated: true)
@@ -176,18 +184,14 @@ final class ApplePayCheckoutViewController: UIViewController {
     
     private func cancelPayment() {
         self.delegate?.track(.paymentCancelled)
-        
+
         self.checkoutProcess.abort(SnabbleCI.project) { result in
             Task { @MainActor in
                 switch result {
                 case .success:
                     Snabble.clearInFlightCheckout()
                     self.shoppingCart.generateNewUUID()
-                    if let cartVC = self.navigationController?.viewControllers.first(where: { $0 is ShoppingCartViewController}) {
-                        self.navigationController?.popToViewController(cartVC, animated: true)
-                    } else {
-                        self.navigationController?.popToRootViewController(animated: true)
-                    }
+                    self.delegate?.checkoutFinished(self.shoppingCart, nil)
 
                 case .failure:
                     let alert = UIAlertController(title: Asset.localizedString(forKey: "Snabble.Payment.CancelError.title"),
@@ -292,11 +296,11 @@ extension ApplePayCheckoutViewController: PKPaymentAuthorizationViewControllerDe
     
     private func paymentFinished(_ checkoutProcess: CheckoutProcess) {
         self.poller = nil
-        
+
         let paymentDisplay = CheckoutStepsViewController(shop: shop,
                                                          shoppingCart: shoppingCart,
                                                          checkoutProcess: checkoutProcess)
         paymentDisplay.paymentDelegate = delegate
-        navigationController?.pushViewController(paymentDisplay, animated: true)
+        delegate?.paymentRequiresNavigation(to: paymentDisplay)
     }
 }

--- a/Payment/Sources/PaymentDelegate.swift
+++ b/Payment/Sources/PaymentDelegate.swift
@@ -29,6 +29,13 @@ public protocol PaymentDelegate: AnalyticsDelegate, MessageDelegate {
     func handlePaymentError(_ method: PaymentMethod, _ error: SnabbleError) -> Bool
 
     func exitToken(_ exitToken: ExitToken, for shop: Shop)
+
+    /// Called when a payment flow needs to navigate to a new view controller.
+    /// UIKit hosts can implement this via UINavigationController directly.
+    /// SwiftUI hosts (e.g. Shopper) implement this to update their driven controller state.
+    /// Must be a protocol requirement (not only an extension default) so dynamic dispatch
+    /// routes to the concrete conformer's implementation, not the static default.
+    func paymentRequiresNavigation(to viewController: UIViewController)
 }
 
 /// provide simple default implementations
@@ -36,4 +43,6 @@ extension PaymentDelegate {
     public func handlePaymentError(_ method: PaymentMethod, _ error: SnabbleError) -> Bool {
         return false
     }
+
+    public func paymentRequiresNavigation(to viewController: UIViewController) {}
 }

--- a/Payment/Sources/PaymentMethods/SwiftUI/List/PaymentMethodAddSheet.swift
+++ b/Payment/Sources/PaymentMethods/SwiftUI/List/PaymentMethodAddSheet.swift
@@ -68,7 +68,7 @@ public struct PaymentMethodAddSheet: View {
                     }
                 }
             }
-            .navigationTitle(Asset.localizedString(forKey: "Snabble.PaymentMethods.choose"))
+            .navigationTitle(Asset.localizedString(forKey: "Snabble.PaymentMethods.add"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/Payment/Sources/PaymentMethods/UIKit/List/PaymentMethodAddViewController.swift
+++ b/Payment/Sources/PaymentMethods/UIKit/List/PaymentMethodAddViewController.swift
@@ -125,7 +125,7 @@ extension PaymentMethodAddViewController {
             .filter { $0.visible }
             .sorted { $0.displayName < $1.displayName }
 
-        let sheet = SelectionSheetController(title: Asset.localizedString(forKey: "Snabble.PaymentMethods.choose"), message: nil)
+        let sheet = SelectionSheetController(title: Asset.localizedString(forKey: "Snabble.PaymentMethods.add"), message: nil)
 
         methods.forEach { method in
             let action = SelectionSheetAction(title: method.displayName, image: method.icon) { [self] _ in

--- a/Payment/Sources/PaymentMethods/UIKit/List/PaymentMethodListViewController.swift
+++ b/Payment/Sources/PaymentMethods/UIKit/List/PaymentMethodListViewController.swift
@@ -121,7 +121,7 @@ extension UIViewController {
        if methods.count == 1 {
            showEditController(for: methods[0], in: projectId, analyticsDelegate: analyticsDelegate)
        } else {
-           let sheet = SelectionSheetController(title: Asset.localizedString(forKey: "Snabble.PaymentMethods.choose"))
+           let sheet = SelectionSheetController(title: Asset.localizedString(forKey: "Snabble.PaymentMethods.add"))
 
            methods.forEach { method in
                let action = SelectionSheetAction(title: method.displayName, image: method.icon) { [self] _ in

--- a/ScanAndGo/Shopping/Models/ActionState.swift
+++ b/ScanAndGo/Shopping/Models/ActionState.swift
@@ -12,6 +12,20 @@ import Combine
 import SnabbleAssetProviding
 import SnabbleComponents
 
+extension String {
+    static func errorString(reason: String) -> String {
+        "\(reason)\nThis should not happen! 😳"
+    }
+}
+
+struct ErrorText: View {
+    let reason: String
+
+    var body: some View {
+        Text(String.errorString(reason: reason))
+    }
+}
+
 /// Represents different types of actions that can be triggered in the application.
 public enum ActionType: Equatable, @unchecked Sendable {
     /// Nothing to display

--- a/ScanAndGo/Shopping/Models/Shopper+Payment.swift
+++ b/ScanAndGo/Shopping/Models/Shopper+Payment.swift
@@ -71,7 +71,7 @@ extension Shopper: PaymentMethodManagerDelegate {
         // if the selected method is missing its detail data, immediately open the edit VC for the method
         if detail == nil,
            let controller = method.editViewController(with: project.id, self) {
-            self.controller = controller
+            self.navigationItem = NavigationItem(viewController: controller)
         } else if method == .applePay && !ApplePay.canMakePayments(with: project.id) {
             ApplePay.openPaymentSetup()
         }
@@ -85,9 +85,24 @@ extension Shopper: PaymentMethodManagerDelegate {
 extension Shopper: PaymentDelegate {
     public func checkoutFinished(_ cart: SnabbleCore.ShoppingCart, _ process: SnabbleCore.CheckoutProcess?) {
         logger.debug("checkout finished with state: \(process?.paymentState.rawValue ?? "unknown")")
+        self.navigationItem = nil
+        let success: Bool
 
-        // CheckoutStepsViewController handles cart clearing, we just dismiss navigation
-        self.isNavigating = false
+        if let paymentState = process?.paymentState {
+            success = PaymentState.successStates.contains(paymentState)
+        } else {
+            success = false
+        }
+        
+        // Notify the host app that the checkout session is complete. Called here (not in
+        // navigationItem.didSet) so that spurious SwiftUI binding write-backs during
+        // UIKit modal presentation do not trigger premature tab switches.
+        Task { @MainActor in self.onCheckoutCompleted?(success) }
+    }
+
+    public func paymentRequiresNavigation(to viewController: UIViewController) {
+        logger.debug("paymentRequiresNavigation: \(String(describing: type(of: viewController)))")
+        replaceController(with: viewController)
     }
     
     public var view: UIView! {

--- a/ScanAndGo/Shopping/Models/Shopper.swift
+++ b/ScanAndGo/Shopping/Models/Shopper.swift
@@ -106,6 +106,17 @@ public final class Shopper: BarcodeProcessing, Equatable {
     /// The successful checkout process to display in the success screen
     public var successfulCheckoutProcess: CheckoutProcess?
 
+    /// A navigation destination wrapping a UIViewController with a stable identity.
+    /// Each instance gets a unique UUID so replacing the target while navigating
+    /// forces SwiftUI's navigationDestination(item:) to rebuild the destination view.
+    public struct NavigationItem: Hashable, @unchecked Sendable {
+        public let id = UUID()
+        public let viewController: UIViewController
+
+        public static func == (lhs: NavigationItem, rhs: NavigationItem) -> Bool { lhs.id == rhs.id }
+        public func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    }
+
     /// Initializes a new Shopper with the specified shop and barcode detector.
     ///
     /// - Parameters:
@@ -202,41 +213,39 @@ public final class Shopper: BarcodeProcessing, Equatable {
             barcodeManager.barcodeDetector.setTorch(flashlight)
         }
     }
-    private var _isNavigating: Bool = false
 
     /// Called when checkout navigation ends and the scanner resumes.
     /// The hosting app can use this to perform custom navigation, e.g. switching to a dashboard tab.
-    @ObservationIgnored public var onCheckoutCompleted: (@MainActor () -> Void)?
+    @ObservationIgnored public var onCheckoutCompleted: (@MainActor (Bool) -> Void)?
 
     /// Called for each analytics event emitted during the shopping session.
     @ObservationIgnored public var onAnalyticsEvent: (@MainActor (SnabbleCore.AnalyticsEvent) -> Void)?
 
-    public var isNavigating: Bool {
-        get { _isNavigating }
-        set {
-            logger.debug("isNavigating changed to: \(newValue)")
-            _isNavigating = newValue
-            if !newValue {
-                controller = nil
-                self.startScanner()
-                // Defer to avoid mutating @Observable state during an active SwiftUI update cycle.
-                Task { @MainActor in
-                    self.onCheckoutCompleted?()
+    /// The current navigation destination. Setting a non-nil value stops the scanner;
+    /// clearing it starts the scanner and calls onCheckoutCompleted.
+    /// Setting a new non-nil value while already navigating replaces the destination
+    /// without any scanner restart — SwiftUI's navigationDestination(item:) rebuilds
+    /// the view because each NavigationItem carries a unique UUID.
+    public var navigationItem: NavigationItem? {
+        didSet {
+            if let item = navigationItem {
+                if oldValue == nil {
+                    stopScanner()
                 }
+                logger.debug("navigationItem set: \(String(describing: type(of: item.viewController)))")
+            } else if oldValue != nil {
+                logger.debug("navigationItem cleared")
+                startScanner()
+                // onCheckoutCompleted is called explicitly by checkoutFinished, not here.
+                // This prevents a spurious SwiftUI binding write-back (e.g. when a UIKit
+                // modal inside the ContainerView is dismissed) from switching tabs prematurely.
             }
         }
     }
 
-    public var controller: UIViewController? {
-        didSet {
-            if let controller {
-                logger.debug("controller set: \(String(describing: type(of: controller)))")
-                self.stopScanner()
-                _isNavigating = true
-            } else {
-                logger.debug("controller set to nil")
-            }
-        }
+    func replaceController(with viewController: UIViewController) {
+        logger.debug("replaceController: \(String(describing: type(of: viewController)))")
+        navigationItem = NavigationItem(viewController: viewController)
     }
     
     /// Resets the scan data.
@@ -298,7 +307,7 @@ extension Shopper: ShoppingCartDelegate {
                 Task { @MainActor in
                     switch result {
                     case .success(let viewController):
-                        self.controller = viewController
+                        self.navigationItem = NavigationItem(viewController: viewController)
                         didStartPayment(true)
                         
                     case .failure(let error):

--- a/ScanAndGo/Shopping/Views/ShopperNavigation.swift
+++ b/ScanAndGo/Shopping/Views/ShopperNavigation.swift
@@ -8,53 +8,12 @@
 import SwiftUI
 import SnabbleComponents
 
-extension String {
-    static func errorString(reason: String) -> String {
-        "\(reason)\nThis should not happen! 😳"
-    }
-}
-struct ErrorText: View {
-    let reason: String
-    
-    var body: some View {
-        Text(String.errorString(reason: reason))
-    }
-}
-
-struct InvalidNavigationView: View {
-    @Binding var isPresented: Bool
-    
-    var body: some View {
-        VStack {
-            Spacer()
-            ErrorText(reason: "Invalid Navigation")
-            Spacer()
-        }
-        .onTapGesture {
-            dismiss()
-        }
-    }
-    
-    /// Dismisses the toast and the full screen cover animated
-    private func dismiss() {
-        withAnimation {
-            isPresented = false
-        }
-    }
-}
-
 extension Shopper {
     @ViewBuilder
-    public func navigationDestination(isPresented: Binding<Bool>) -> some View {
-        if let controller {
-            ContainerView(viewController: controller)
-                .navigationTitle(controller.navigationItem.title ?? "Navigation")
-        } else {
-            InvalidNavigationView(isPresented: isPresented)
+    public func navigationDestinationView() -> some View {
+        if let item = navigationItem {
+            ContainerView(viewController: item.viewController)
+                .navigationTitle(item.viewController.navigationItem.title ?? "")
         }
     }
-}
-
-#Preview {
-    InvalidNavigationView(isPresented: .constant(true))
 }

--- a/ScanAndGo/Shopping/Views/ShopperView.swift
+++ b/ScanAndGo/Shopping/Views/ShopperView.swift
@@ -34,6 +34,7 @@ public struct ShopperView: View {
     @State private var showSearch: Bool = false
     @State private var showError: Bool = false
     @State private var showBundleSelection: Bool = false
+    @State private var isNavigating: Bool = false
 
     @State private var minHeight: CGFloat = 0
     @State private var bundles: [BarcodeManager.ScannedItem] = []
@@ -51,8 +52,26 @@ public struct ShopperView: View {
         
         ShoppingScannerView(model: model, minHeight: $minHeight, configuration: configuration)
             .animation(.easeInOut, value: model.scannedItem)
-            .navigationDestination(isPresented: $model.isNavigating) {
-                model.navigationDestination(isPresented: $model.isNavigating)
+            .navigationDestination(isPresented: $isNavigating) {
+                if let item = model.navigationItem {
+                    ContainerView(viewController: item.viewController)
+                        .navigationTitle(item.viewController.navigationItem.title ?? "")
+                }
+            }
+            .onChange(of: model.navigationItem, initial: true) { _, item in
+                // Sync model → local state. Keeping isNavigating as local @State means
+                // SwiftUI's internal binding write-backs (e.g. during a replace transition)
+                // don't reach the model's didSet side effects.
+                let shouldNavigate = item != nil
+                if isNavigating != shouldNavigate {
+                    isNavigating = shouldNavigate
+                }
+            }
+            .onChange(of: isNavigating) { _, navigating in
+                // Propagate user-initiated back-navigation to the model.
+                if !navigating {
+                    model.navigationItem = nil
+                }
             }
             .alert(Asset.localizedString(forKey: "Snabble.SaleStop.ErrorMsg.title"), isPresented: $showError) {
                 Button(Asset.localizedString(forKey: "Snabble.ok")) {


### PR DESCRIPTION
Replaces `isNavigating: Bool + controller: UIViewController?` in Shopper with a single `navigationItem: NavigationItem?` property. Each `NavigationItem` carries a stable UUID so SwiftUI can distinguish replace-in-place transitions (ApplePayVC → CheckoutStepsVC) from dismiss events.

ShopperView uses a local `@State isNavigating` as the binding target for `navigationDestination(isPresented:)` and syncs it via `onChange` — prevents SwiftUI's internal binding write-backs from triggering scanner restarts or tab switches prematurely.

`ContainerView.updateUIViewController` now replaces the hosted child VC in-place when the `viewController` reference changes, without tearing down the navigation stack.

`paymentRequiresNavigation(to:)` promoted to a `PaymentDelegate` protocol requirement to ensure dynamic dispatch works correctly.

https://snabble.atlassian.net/browse/APPS-2667