### PR TITLE
Fix: Barcode Scanner & PullOverView Stability #Apps-2668

### DIFF
--- a/Core/Sources/API/SDKVersion.swift
+++ b/Core/Sources/API/SDKVersion.swift
@@ -1,9 +1,9 @@
 //
-//  APIVersion.swift
+//  SDKVersion.swift
 //
 //  Copyright © 2021 snabble. All rights reserved.
 //
 
 public var SDKVersion: String {
-    "1.1.1"
+    "1.1.2"
 }

--- a/Core/Sources/Checkin/CheckInManager.swift
+++ b/Core/Sources/Checkin/CheckInManager.swift
@@ -36,7 +36,10 @@ public class CheckInManager: NSObject, @unchecked Sendable {
     /// Current checked in `Shop`
     public var shop: Shop? {
         didSet {
-            shopContinuation?.yield(shop)
+            let newShop = shop
+            Task { @MainActor in
+                state.update(shop: newShop)
+            }
             if let shop = oldValue {
                 checkedInAt = nil
                 delegate?.checkInManager(self, didCheckOutOf: shop)
@@ -49,53 +52,11 @@ public class CheckInManager: NSObject, @unchecked Sendable {
         }
     }
 
-    // MARK: - Combine API (Legacy)
+    // MARK: - Observable State (Modern)
 
-    /// Thread-safety: Combine publishers are thread-safe
-    @available(*, deprecated, message: "Use shopStream instead for modern Swift concurrency")
-    nonisolated(unsafe) public var shopPublisher = CurrentValueSubject<Shop?, Never>(nil)
-
-    /// Thread-safety: Combine publishers are thread-safe
-    @available(*, deprecated, message: "Use authorizationStream instead for modern Swift concurrency")
-    nonisolated(unsafe) public let authorizationStatusSubject = PassthroughSubject<CLAuthorizationStatus, Never>()
-
-    // MARK: - AsyncStream API (Modern)
-
-    private var shopContinuation: AsyncStream<Shop?>.Continuation?
-    private var authorizationContinuation: AsyncStream<CLAuthorizationStatus>.Continuation?
-
-    /// Modern async stream for observing shop check-in changes
-    ///
-    /// Example usage:
-    /// ```swift
-    /// Task {
-    ///     for await shop in checkInManager.shopStream {
-    ///         print("Checked into: \(shop?.name ?? "none")")
-    ///     }
-    /// }
-    /// ```
-    public var shopStream: AsyncStream<Shop?> {
-        AsyncStream { continuation in
-            self.shopContinuation = continuation
-            continuation.yield(self.shop)
-        }
-    }
-
-    /// Modern async stream for observing location authorization changes
-    ///
-    /// Example usage:
-    /// ```swift
-    /// Task {
-    ///     for await status in checkInManager.authorizationStream {
-    ///         print("Authorization: \(status)")
-    ///     }
-    /// }
-    /// ```
-    public var authorizationStream: AsyncStream<CLAuthorizationStatus> {
-        AsyncStream { continuation in
-            self.authorizationContinuation = continuation
-        }
-    }
+    /// Observable check-in state. SwiftUI views automatically track changes to `state.shop`
+    /// without needing a `.task` or `for await` loop.
+    public let state = CheckInState()
 
     private func trackCheckIn(with shop: Shop) {
         guard let location = locationManager.location, let project = shop.project else { return }
@@ -186,7 +147,6 @@ extension CheckInManager: CLLocationManagerDelegate {
         @unknown default:
             break
         }
-        authorizationContinuation?.yield(manager.authorizationStatus)
     }
 
     @available(iOS 14.0, *)

--- a/Core/Sources/Checkin/CheckInState.swift
+++ b/Core/Sources/Checkin/CheckInState.swift
@@ -1,0 +1,22 @@
+//
+//  CheckInState.swift
+//  Snabble
+//
+
+import Observation
+
+/// Observable check-in state for use with SwiftUI.
+///
+/// Access via `Snabble.shared.checkInManager.state`. SwiftUI views automatically
+/// re-render when `shop` changes without needing a `.task` or `for await` loop.
+@Observable
+public final class CheckInState {
+    /// The currently checked-in shop, or `nil` if not checked in.
+    public private(set) var shop: Shop?
+
+    init() {}
+
+    func update(shop: Shop?) {
+        self.shop = shop
+    }
+}

--- a/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
+++ b/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
@@ -13,8 +13,22 @@
 		76DF385B2F5075A80050F4EC /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 76DF385A2F5075A80050F4EC /* Snabble */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		768DF8DB3008FF7200149045 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		768D2E7B2F9F410A00566A40 /* SnabbleSampleApp-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SnabbleSampleApp-Info.plist"; sourceTree = "<group>"; };
+		768DF8C83008FF7000149045 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		76DF38052F50740F0050F4EC /* SnabbleSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SnabbleSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -41,10 +55,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		768DF8C53008FF7000149045 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				768DF8C83008FF7000149045 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		76DF37FC2F50740F0050F4EC = {
 			isa = PBXGroup;
 			children = (
 				76DF38072F50740F0050F4EC /* SwiftySnabble */,
+				768DF8C53008FF7000149045 /* Frameworks */,
 				76DF38062F50740F0050F4EC /* Products */,
 				768D2E7B2F9F410A00566A40 /* SnabbleSampleApp-Info.plist */,
 			);
@@ -70,6 +93,7 @@
 				76DF38012F50740F0050F4EC /* Sources */,
 				76DF38022F50740F0050F4EC /* Frameworks */,
 				76DF38032F50740F0050F4EC /* Resources */,
+				768DF8DB3008FF7200149045 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
@@ -96,8 +120,8 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2630;
-				LastUpgradeCheck = 2630;
+				LastSwiftUpdateCheck = 2660;
+				LastUpgradeCheck = 2660;
 				TargetAttributes = {
 					76DF38042F50740F0050F4EC = {
 						CreatedOnToolsVersion = 26.3;
@@ -229,6 +253,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 53K7JS449L;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -292,6 +317,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 53K7JS449L;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -321,6 +347,7 @@
 				CODE_SIGN_ENTITLEMENTS = SwiftySnabble/SwiftySnabble.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 53K7JS449L;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -374,6 +401,7 @@
 				CODE_SIGN_ENTITLEMENTS = SwiftySnabble/SwiftySnabble.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 53K7JS449L;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;

--- a/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/SnabbleSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {

--- a/Example/SnabbleSampleApp.xcodeproj/xcshareddata/xcschemes/SwiftySnabble.xcscheme
+++ b/Example/SnabbleSampleApp.xcodeproj/xcshareddata/xcschemes/SwiftySnabble.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2630"
+   LastUpgradeVersion = "2660"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Example/SwiftySnabble/Core/AppState.swift
+++ b/Example/SwiftySnabble/Core/AppState.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import CoreLocation
 
 import SnabbleCore
 
@@ -16,6 +17,20 @@ final class AppState {
     var project: Project?
     var shops: [Shop] = []
     var checkedInShop: Shop?
-    
+
     init() { }
+}
+
+extension AppState: CheckInManagerDelegate {
+    nonisolated func checkInManager(_ checkInManager: CheckInManager, didCheckInTo shop: Shop) {
+        Task { @MainActor [self] in checkedInShop = shop }
+    }
+
+    nonisolated func checkInManager(_ checkInManager: CheckInManager, didCheckOutOf shop: Shop) {
+        Task { @MainActor [self] in checkedInShop = nil }
+    }
+
+    nonisolated func checkInManager(_ checkInManager: CheckInManager, locationAuthorizationNotGranted authorizationStatus: CLAuthorizationStatus) {}
+    nonisolated func checkInManager(_ checkInManager: CheckInManager, locationAccuracyNotSufficient accuracyAuthorization: CLAccuracyAuthorization) {}
+    nonisolated func checkInManager(_ checkInManager: CheckInManager, didFailWithError error: Error) {}
 }

--- a/Example/SwiftySnabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Example/SwiftySnabble/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -12,7 +12,7 @@ name: ios-sdk, nameSpecified: Datatrans, owner: datatrans, version: 3.11.0, sour
 
 name: KeychainAccess, nameSpecified: KeychainAccess, owner: kishikawakatsumi, version: 4.2.2, source: https://github.com/kishikawakatsumi/KeychainAccess
 
-name: swift-asn1, nameSpecified: swift-asn1, owner: apple, version: 1.7.0, source: https://github.com/apple/swift-asn1
+name: swift-asn1, nameSpecified: swift-asn1, owner: apple, version: 1.7.1, source: https://github.com/apple/swift-asn1
 
 name: swift-crypto, nameSpecified: swift-crypto, owner: apple, version: 3.15.1, source: https://github.com/apple/swift-crypto
 

--- a/Example/SwiftySnabble/Support/Localizable.xcstrings
+++ b/Example/SwiftySnabble/Support/Localizable.xcstrings
@@ -71,17 +71,6 @@
         }
       }
     },
-    "Developer" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entwickler"
-          }
-        }
-      }
-    },
     "Environment" : {
 
     },
@@ -354,17 +343,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Einkaufen starten"
-          }
-        }
-      }
-    },
-    "This feature is in development" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Funktion ist in Entwicklung"
           }
         }
       }

--- a/Example/SwiftySnabble/SwiftySnabbleApp.swift
+++ b/Example/SwiftySnabble/SwiftySnabbleApp.swift
@@ -18,13 +18,13 @@ import SnabbleScanAndGo
 
 @main
 struct SwiftySnabbleApp: App {
-    
+
     @State private var router = AppRouter()
     @State private var appState = AppState()
     @State private var isInitialized = false
 
     let provider = AppAssetProvider()
-    
+
     init() {
         Asset.provider = provider
     }
@@ -57,13 +57,11 @@ struct SwiftySnabbleApp: App {
             }
 
             SnabbleCI.register(project)
-            
+
             Task { @MainActor in
-                for await shop in snabble.checkInManager.shopStream {
-                    appState.checkedInShop = shop
-                }
+                snabble.checkInManager.delegate = appState
+                snabble.checkInManager.startUpdating()
             }
-            snabble.checkInManager.startUpdating()
 
             snabble.setupProductDatabase(for: project) { _ in
                 Task { @MainActor in

--- a/Example/com.mono0926.LicensePlist.Output/com.mono0926.LicensePlist.latest_result.txt
+++ b/Example/com.mono0926.LicensePlist.Output/com.mono0926.LicensePlist.latest_result.txt
@@ -12,7 +12,7 @@ name: ios-sdk, nameSpecified: Datatrans, owner: datatrans, version: 3.11.0, sour
 
 name: KeychainAccess, nameSpecified: KeychainAccess, owner: kishikawakatsumi, version: 4.2.2, source: https://github.com/kishikawakatsumi/KeychainAccess
 
-name: swift-asn1, nameSpecified: swift-asn1, owner: apple, version: 1.7.0, source: https://github.com/apple/swift-asn1
+name: swift-asn1, nameSpecified: swift-asn1, owner: apple, version: 1.7.1, source: https://github.com/apple/swift-asn1
 
 name: swift-crypto, nameSpecified: swift-crypto, owner: apple, version: 3.15.1, source: https://github.com/apple/swift-crypto
 

--- a/Package.swift
+++ b/Package.swift
@@ -113,7 +113,6 @@ let package = Package(
         .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.19")),
         .package(url: "https://github.com/datatrans/ios-sdk.git", from: "3.7.3"),
         .package(url: "https://github.com/devicekit/DeviceKit.git", from: "5.5.0"),
-        // Pulley removed - legacy scanner deleted
         .package(url: "https://github.com/chrs1885/WCAG-Colors.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
         .package(url: "https://github.com/divadretlaw/WindowKit", from: "2.5.2"),

--- a/Payment/Sources/PaymentMethods/SwiftUI/Pure/PaymentSubjectView.swift
+++ b/Payment/Sources/PaymentMethods/SwiftUI/Pure/PaymentSubjectView.swift
@@ -18,7 +18,7 @@ public struct PaymentSubjectView: View {
     @State private var subject: String = ""
     
     private func subjectLimit() -> Int? {
-        guard let projectId = Snabble.shared.checkInManager.shop?.projectId else {
+        guard let projectId = Snabble.shared.checkInManager.state.shop?.projectId else {
             return nil
         }
         let customProperty = Snabble.shared.config.customProperties.first { customProperty, _ in

--- a/ScanAndGo/Shopping/Models/InternalBarcodeDetector.swift
+++ b/ScanAndGo/Shopping/Models/InternalBarcodeDetector.swift
@@ -246,6 +246,24 @@ open class InternalBarcodeDetector: NSObject, Zoomable, @unchecked Sendable {
         self.startBatterySaverTimer()
         self.state = .scanning
         self.setRecommendedZoomFactor()
+        // Re-apply zoom on the session queue after startRunning() to handle rapid
+        // show/hide cycles: a pending stopRunning() can cancel a ramp and leave
+        // videoZoomFactor at 1.0. Running after startRunning() on the serial queue
+        // guarantees the session is live and the direct set takes effect.
+        if let zoom = self.zoomFactor, let camera = self.camera {
+            let minZoom = camera.minAvailableVideoZoomFactor
+            let maxZoom = camera.maxAvailableVideoZoomFactor
+            self.sessionQueue.async {
+                guard zoom >= minZoom, zoom <= maxZoom else { return }
+                do {
+                    try camera.lockForConfiguration()
+                    camera.videoZoomFactor = zoom
+                    camera.unlockForConfiguration()
+                } catch {
+                    // ignore
+                }
+            }
+        }
     }
     
     open func setTorch(_ switchedOn: Bool) {

--- a/ScanAndGo/Shopping/Views/BarcodeScannerView.swift
+++ b/ScanAndGo/Shopping/Views/BarcodeScannerView.swift
@@ -30,7 +30,7 @@ class BarcodeScannerViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .systemGray
+        self.view.backgroundColor = .black
         
         if let previewLayer = detector.previewLayer {
             addLayer(previewLayer, to: self)
@@ -38,14 +38,10 @@ class BarcodeScannerViewController: UIViewController {
     }
 
     func addLayer(_ layer: CALayer, to viewController: UIViewController) {
-        let frame = viewController.view.bounds
-        let insets = UIApplication.shared.sceneKeyWindow?.safeAreaInsets ?? UIEdgeInsets()
-        
-        let rect = CGRect(x: 0, y: 0, width: frame.width, height: frame.height - insets.top - insets.bottom - UITabBarController().height)
-        
-        layer.frame = rect
-        logger.debug("preview layer size: \(rect.width) x \(rect.height)")
-        
+        let bounds = viewController.view.bounds
+        layer.frame = bounds
+        logger.debug("preview layer size: \(bounds.width) x \(bounds.height)")
+
         if layer.superlayer == nil {
             Task { @MainActor in
                 viewController.view.layer.addSublayer(layer)

--- a/ScanAndGo/Shopping/Views/PullOverView.swift
+++ b/ScanAndGo/Shopping/Views/PullOverView.swift
@@ -10,39 +10,6 @@ import SwiftUI
 import SnabbleAssetProviding
 import SnabbleComponents
 
-struct DraggableModifier: ViewModifier {
-    enum Direction {
-        case vertical
-        case horizontal
-    }
-    
-    let direction: Direction
-    
-    @State private var draggedOffset: CGSize = .zero
-    
-    func body(content: Content) -> some View {
-        content
-            .offset(
-                CGSize(width: direction == .vertical ? 0 : draggedOffset.width,
-                       height: direction == .horizontal ? 0 : draggedOffset.height)
-            )
-            .gesture(
-                DragGesture()
-                    .onChanged { value in
-                        self.draggedOffset = value.translation
-                    }
-                    .onEnded { _ in
-                        self.draggedOffset = .zero
-                    }
-            )
-    }
-}
-extension View {
-    func dragDirection(_ direction: DraggableModifier.Direction) -> some View {
-        modifier(DraggableModifier(direction: direction))
-    }
-}
-
 extension DragGesture.Value {
     var isVertical: Bool {
         abs(startLocation.y - location.y) > abs(startLocation.x - location.x)
@@ -97,14 +64,16 @@ struct PullView: ViewModifier {
     @Binding var position: CGFloat
     @Binding var isDragging: Bool
     
-    @GestureState private var dragTracker = CGSize.zero
+    @State private var dragOffset: CGFloat = 0
     @State private var minYPosition: CGFloat = 0
+    @State private var directionUp: Bool = false
     
     func maxHeight(_ geom: GeometryProxy) -> CGFloat {
         geom.size.height
     }
     func setupMinHeight(geom: GeometryProxy) {
-        minYPosition = maxHeight(geom) - UITabBarController().height - (minHeight > 0 ? minHeight : paddingTop)
+        guard geom.size.height > 0, !isDragging else { return }
+        minYPosition = maxHeight(geom) - (minHeight > 0 ? minHeight : paddingTop)
         position = expanded ? paddingTop : minYPosition
     }
     func body(content: Content) -> some View {
@@ -124,7 +93,9 @@ struct PullView: ViewModifier {
             .clipShape(CardShape(radius: 24))
             .onAppear {
                 setupMinHeight(geom: geom)
-
+            }
+            .onChange(of: geom.size.height) {
+                setupMinHeight(geom: geom)
             }
             .onChange(of: minHeight) {
                 setupMinHeight(geom: geom)
@@ -132,55 +103,64 @@ struct PullView: ViewModifier {
             .onChange(of: paddingTop) {
                 setupMinHeight(geom: geom)
             }
-            .frame(maxHeight: CGFloat(max(maxHeight(geom) - (position + self.dragTracker.height), 0)))
-            .offset(y: max(0, position + self.dragTracker.height))
-            .animation(.easeInOut(duration: 0.2), value: position)
-            .animation(Animation.interpolatingSpring(stiffness: 250.0, damping: 40.0, initialVelocity: 5.0), value: isDragging)
+            .onChange(of: expanded) {
+                setupMinHeight(geom: geom)
+            }
+            .frame(maxHeight: CGFloat(max(maxHeight(geom) - (position + dragOffset), 0)))
+            .offset(y: max(0, position + dragOffset))
             .opacity(position == 0 ? 0 : 1)
-            .simultaneousGesture(DragGesture(minimumDistance: 50, coordinateSpace: .local)
-                .updating($dragTracker) { drag, state, _ in
-                    if drag.isVertical {
-                        state = drag.translation
-                    }
-                }
+            .simultaneousGesture(DragGesture(minimumDistance: 10, coordinateSpace: .local)
                 .onChanged { drag in
-                    if drag.isVertical {
-                        isDragging = true
+                    guard drag.isVertical else { return }
+                    isDragging = true
+                    dragOffset = drag.translation.height
+                    directionUp = drag.translation.height > 0
+                }
+                .onEnded { drag in
+                    isDragging = false
+                    guard drag.isVertical else {
+                        dragOffset = 0
+                        return
+                    }
+                    // Commit the current visual position before animating to the target.
+                    // Without this, resetting dragOffset to 0 causes a visible jump because
+                    // the animation would start from position (the old stored value) instead
+                    // of from where the view actually is on screen.
+                    let currentVisual = position + dragOffset
+                    let shouldCollapse = directionUp
+                    let targetPosition = shouldCollapse ? minYPosition : paddingTop
+                    let targetExpanded = !shouldCollapse
+
+                    position = currentVisual
+                    dragOffset = 0
+
+                    Task { @MainActor in
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            position = targetPosition
+                            expanded = targetExpanded
+                        }
                     }
                 }
-                .onEnded(onDragEnded)
             )
         }
-        
     }
     func expand() {
-        expanded = true
-        position = paddingTop
+        withAnimation(.easeInOut(duration: 0.2)) {
+            expanded = true
+            position = paddingTop
+        }
     }
     func collapse() {
-        expanded = false
-        position = minYPosition
+        withAnimation(.easeInOut(duration: 0.2)) {
+            expanded = false
+            position = minYPosition
+        }
     }
     func toggle() {
         if position == minYPosition {
             expand()
         } else {
             collapse()
-        }
-    }
-    private func onDragEnded(drag: DragGesture.Value) {
-        isDragging = false
-        
-        guard drag.isVertical else {
-            return
-        }
-        let dragDirection = drag.predictedEndLocation.y - drag.location.y
-        // can also calculate drag offset to make it more rigid to shrink and expand
-        if dragDirection > 0 {
-            position = minYPosition
-            collapse()
-        } else {
-            expand()
         }
     }
 }

--- a/ScanAndGo/Shopping/Views/ScannerCartView.swift
+++ b/ScanAndGo/Shopping/Views/ScannerCartView.swift
@@ -7,29 +7,26 @@
 
 import SwiftUI
 
-import SnabbleCore
-import SnabbleAssetProviding
 import SnabbleCart
 
 struct ScannerCartView: View {
-    let model: Shopper
-
     static let TopMargin = CGFloat(20)
 
+    let model: Shopper
     @Binding var minHeight: CGFloat
+    let offset: CGFloat
 
     @State private var compactMode: Bool = true
 
-    @ScaledMetric private var barHeight = CGFloat(74)
-    @ScaledMetric private var visibleRowHeight = CGFloat(72)
-    let offset: CGFloat
+    @ScaledMetric private var barHeight = CGFloat(128)
+    @ScaledMetric private var visibleRowHeight = CGFloat(99)
 
     init(model: Shopper, minHeight: Binding<CGFloat>, offset: CGFloat = 0) {
         self.model = model
         self._minHeight = minHeight
         self.offset = offset
     }
-    
+
     var body: some View {
         VStack(spacing: 0) {
             CartCheckoutBarView(model: model)
@@ -50,7 +47,7 @@ struct ScannerCartView: View {
             update()
         }
     }
-    
+
     func update() {
         let count = model.barcodeManager.shoppingCart.numberOfItems
         let avg = visibleRowHeight

--- a/ScanAndGo/Shopping/Views/ShoppingScannerView.swift
+++ b/ScanAndGo/Shopping/Views/ShoppingScannerView.swift
@@ -75,12 +75,12 @@ struct ShoppingScannerView: View {
                 .offset(x: 0, y: position - configuration.zoomControlOffset)
                 .opacity(model.scanningPaused || position == 0 ? 0 : 1)
             
-            if model.barcodeManager.barcodeDetector.state != .idle {
-                PullOverView(minHeight: $minHeight, expanded: $model.scanningPaused, paddingTop: $topMargin, position: $position, isDragging: $isDragging) {
-                    ScannerCartView(model: model, minHeight: $minHeight, offset: configuration.drawerOffset)
-                        .disabled(isDragging)
-                }
+            PullOverView(minHeight: $minHeight, expanded: $model.scanningPaused, paddingTop: $topMargin, position: $position, isDragging: $isDragging) {
+                ScannerCartView(model: model, minHeight: $minHeight, offset: configuration.drawerOffset)
+                    .disabled(isDragging)
             }
+            .opacity(model.barcodeManager.barcodeDetector.state != .idle ? 1 : 0)
+            .allowsHitTesting(model.barcodeManager.barcodeDetector.state != .idle)
             if model.processing || position == 0 {
                 ScannerProcessingView()
             }

--- a/Shops/Sources/Model/ShopsViewModel.swift
+++ b/Shops/Sources/Model/ShopsViewModel.swift
@@ -47,7 +47,7 @@ public final class ShopsViewModel: NSObject {
 
     @MainActor
     public func isCurrent(_ shop: ShopProviding) -> Bool {
-        Snabble.shared.checkInManager.isCheckedIn(for: shop)
+        Snabble.shared.checkInManager.state.shop?.id == shop.id
     }
 
     public let locationManager: CLLocationManager

--- a/Shops/Sources/Views/ShopCellView.swift
+++ b/Shops/Sources/Views/ShopCellView.swift
@@ -15,10 +15,13 @@ import SnabbleComponents
 
 public struct ShopCellView: View {
     let shop: ShopProviding
-    
+
     @State var viewModel: ShopsViewModel
-    @State private var isCurrentShop = false
-    
+
+    private var isCurrentShop: Bool {
+        Snabble.shared.checkInManager.state.shop?.id == shop.id
+    }
+
     public var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 8) {
@@ -37,11 +40,6 @@ public struct ShopCellView: View {
             } else {
                 DistanceView(distance: viewModel.distance(from: shop))
                     .secondaryStyle()
-            }
-        }
-        .task {
-            for await shop in Snabble.shared.checkInManager.shopStream {
-                self.isCurrentShop = shop?.id == self.shop.id
             }
         }
     }

--- a/Shops/Sources/Views/ShopView.swift
+++ b/Shops/Sources/Views/ShopView.swift
@@ -160,6 +160,6 @@ public struct ShopView: View {
     }
     
     private func isCheckedIn() -> Bool {
-        return Snabble.shared.checkInManager.shop?.id == self.shop.id
+        return Snabble.shared.checkInManager.state.shop?.id == self.shop.id
     }
 }


### PR DESCRIPTION
### Changes

• **Camera zoom not restored after rapid show/hide cycles:** Re-apply zoom on the session queue after `startRunning()` to ensure the zoom level is correctly restored when the scanner is quickly hidden and shown again.
• **PullOverView recreated on every scanningPaused change:** Moved the paused-state handling out of the view identity expression so `PullOverView` is no longer torn down and rebuilt on each state change.
• **PullOverView drag gesture issues:** Simplified and rewrote the drag gesture logic to fix uncontrolled snapping and incorrect positioning.
• **ScannerCartView minHeight calculation:** Updated to use corrected values for the bottom sheet height calculation.
• **Observable check-in state:** Introduced `CheckInState` to make shop check-in changes observable. Cleaned up `CheckInManager` and removed deprecated code.
• **AppState shop tracking:** Sample app now correctly observes check-in changes via `CheckInState`.

https://snabble.atlassian.net/browse/APPS-2668