### PR TITLE
Replace magic height constants with dynamic measurement in ScannerCartView #Apps-2669

### DIFF
--- a/Cart/Sources/Views/ShoppingCartItemsView.swift
+++ b/Cart/Sources/Views/ShoppingCartItemsView.swift
@@ -44,6 +44,7 @@ extension ShoppingCartViewModel {
 public struct ShoppingCartItemsView<Footer: View>: View {
     @Bindable var cartModel: ShoppingCartViewModel
     var footer: Footer
+    var onPreviewRowHeight: ((Int, CGFloat) -> Void)?
 
     @State private var itemToDelete: CartEntry? = nil
     @State private var showingDeleteAlert = false
@@ -57,9 +58,14 @@ public struct ShoppingCartItemsView<Footer: View>: View {
         } else {
             List {
                 Section(footer: footer) {
-                    ForEach(cartModel.items, id: \.id) { item in
+                    ForEach(Array(cartModel.items.enumerated()), id: \.element.id) { index, item in
                         cartModel.view(for: item)
                             .environment(cartModel)
+                            .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                                if index < 2 {
+                                    onPreviewRowHeight?(index, height)
+                                }
+                            }
                             .swipeActions(allowsFullSwipe: false) {
                                  Button {
                                      cartModel.trash(item: item)

--- a/Cart/Sources/Views/ShoppingCartView.swift
+++ b/Cart/Sources/Views/ShoppingCartView.swift
@@ -11,17 +11,24 @@ import SnabbleCore
 public struct ShoppingCartView: View {
     @Bindable var cartModel: ShoppingCartViewModel
     let compactMode: Bool
-    
-    public init(cartModel: ShoppingCartViewModel, 
-                compactMode: Bool = false) {
+    var onPreviewRowHeight: ((Int, CGFloat) -> Void)?
+
+    public init(cartModel: ShoppingCartViewModel,
+                compactMode: Bool = false,
+                onPreviewRowHeight: ((Int, CGFloat) -> Void)? = nil
+    ) {
         self.cartModel = cartModel
         self.compactMode = compactMode
+        self.onPreviewRowHeight = onPreviewRowHeight
     }
 
-    public init(shoppingCart: ShoppingCart, 
-                compactMode: Bool = false) {
+    public init(shoppingCart: ShoppingCart,
+                compactMode: Bool = false,
+                onPreviewRowHeight: ((Int, CGFloat) -> Void)? = nil
+    ) {
         self.cartModel = ShoppingCartViewModel(shoppingCart: shoppingCart)
         self.compactMode = compactMode
+        self.onPreviewRowHeight = onPreviewRowHeight
     }
 
     @ViewBuilder
@@ -37,7 +44,7 @@ public struct ShoppingCartView: View {
                 Text(keyed: "Snabble.Shoppingcart.EmptyState.description")
             }
         } else {
-            ShoppingCartItemsView(cartModel: cartModel, footer: footer)
+            ShoppingCartItemsView(cartModel: cartModel, footer: footer, onPreviewRowHeight: onPreviewRowHeight)
                 .onChange(of: cartModel.items) {
                     print("ShoppingCartView: cartModel.items did change")
                 }

--- a/Example/SwiftySnabble/Features/Shopping/ShoppingView.swift
+++ b/Example/SwiftySnabble/Features/Shopping/ShoppingView.swift
@@ -71,7 +71,7 @@ struct ShoppingView: View {
 
     var body: some View {
         NavigationStack {
-            ShopperView(model: shopper)
+            ShopperView(model: shopper, configuration: .init(drawerOffset: 20))
                 .navigationBarHidden(false)
         }
     }

--- a/ScanAndGo/Shopping/Views/PullOverView.swift
+++ b/ScanAndGo/Shopping/Views/PullOverView.swift
@@ -57,7 +57,9 @@ struct PullOverView<Content>: View where Content: View {
 }
 
 struct PullView: ViewModifier {
-    
+    // Top padding added above the content to make room for the drag handle
+    static let contentTopPadding: CGFloat = 16
+
     @Binding var minHeight: CGFloat
     @Binding var expanded: Bool
     @Binding var paddingTop: CGFloat
@@ -86,7 +88,7 @@ struct PullView: ViewModifier {
                     .onTapGesture {
                         toggle()
                     }
-                content.padding(.top, 16)
+                content.padding(.top, PullView.contentTopPadding)
             }
             .frame(minWidth: UIScreen.main.bounds.width)
             .background(.regularMaterial)

--- a/ScanAndGo/Shopping/Views/PullOverView.swift
+++ b/ScanAndGo/Shopping/Views/PullOverView.swift
@@ -110,6 +110,7 @@ struct PullView: ViewModifier {
             }
             .frame(maxHeight: CGFloat(max(maxHeight(geom) - (position + dragOffset), 0)))
             .offset(y: max(0, position + dragOffset))
+            .animation(.default, value: minYPosition)
             .opacity(position == 0 ? 0 : 1)
             .simultaneousGesture(DragGesture(minimumDistance: 10, coordinateSpace: .local)
                 .onChanged { drag in

--- a/ScanAndGo/Shopping/Views/ScannerCartView.swift
+++ b/ScanAndGo/Shopping/Views/ScannerCartView.swift
@@ -18,8 +18,8 @@ struct ScannerCartView: View {
 
     @State private var compactMode: Bool = true
 
-    @ScaledMetric private var barHeight = CGFloat(128)
-    @ScaledMetric private var visibleRowHeight = CGFloat(99)
+    @State private var measuredBarHeight: CGFloat = 0
+    @State private var measuredRowHeights: [CGFloat] = [0, 0]
 
     init(model: Shopper, minHeight: Binding<CGFloat>, offset: CGFloat = 0) {
         self.model = model
@@ -30,29 +30,42 @@ struct ScannerCartView: View {
     var body: some View {
         VStack(spacing: 0) {
             CartCheckoutBarView(model: model)
-            ShoppingCartView(cartModel: model.cartModel, compactMode: compactMode)
+                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                    measuredBarHeight = height
+                    updateMinHeight()
+                }
+            ShoppingCartView(cartModel: model.cartModel, compactMode: compactMode) { index, height in
+                measuredRowHeights[index] = height
+                updateMinHeight()
+            }
             // Without this Spacer(), we have a transparent background
             Spacer(minLength: 1)
         }
         .animation(.default, value: minHeight)
-        .onAppear {
-            update()
-        }
         .task {
             for await _ in NotificationCenter.default.notifications(named: .snabbleCartUpdated) {
-                update()
+                updateMinHeight()
             }
         }
         .onChange(of: model.cartModel.items) {
-            update()
+            updateMinHeight()
         }
     }
 
-    func update() {
+    func updateMinHeight() {
+        guard measuredBarHeight > 0 else { return }
         let count = model.barcodeManager.shoppingCart.numberOfItems
-        let avg = visibleRowHeight
-        
-        // swiftlint:disable:next empty_count
-        minHeight = barHeight + offset + (count == 0 ? 0 : (count > 1 ? avg + avg : avg))
+        // listRowInsets adds 4pt top + 4pt bottom per row
+        let rowInsets: CGFloat = 8
+        let rowsHeight: CGFloat
+        switch count {
+        case 0:
+            rowsHeight = 0
+        case 1:
+            rowsHeight = measuredRowHeights[0] + rowInsets
+        default:
+            rowsHeight = measuredRowHeights[0] + measuredRowHeights[1] + rowInsets * 2
+        }
+        minHeight = measuredBarHeight + offset + rowsHeight
     }
 }

--- a/ScanAndGo/Shopping/Views/ShoppingScannerView.swift
+++ b/ScanAndGo/Shopping/Views/ShoppingScannerView.swift
@@ -76,7 +76,7 @@ struct ShoppingScannerView: View {
                 .opacity(model.scanningPaused || position == 0 ? 0 : 1)
             
             PullOverView(minHeight: $minHeight, expanded: $model.scanningPaused, paddingTop: $topMargin, position: $position, isDragging: $isDragging) {
-                ScannerCartView(model: model, minHeight: $minHeight, offset: configuration.drawerOffset)
+                ScannerCartView(model: model, minHeight: $minHeight, offset: PullView.contentTopPadding + configuration.drawerOffset)
                     .disabled(isDragging)
             }
             .opacity(model.barcodeManager.barcodeDetector.state != .idle ? 1 : 0)


### PR DESCRIPTION
The collapsed drawer height was calculated from two hardcoded values (`barHeight = 128`, `visibleRowHeight = 99`) that broke whenever cart items had discounts, images, or deposit info, or when accessibility font sizes changed.

#### Changes:

• `CartCheckoutBarView` now reports its actual rendered height via `onGeometryChange`
• The first two cart rows each report their individual heights via a callback through `ShoppingCartView` → `ShoppingCartItemsView`
• `ScannerCartView.updateMinHeight()` sums the measured values instead of estimating
• `PullView.contentTopPadding` (16pt) is extracted as a named constant and explicitly added to the offset in `ShoppingScannerView`, so the structural drawer padding is accounted for

https://snabble.atlassian.net/browse/APPS-2669