### PR TITLE
Fix: ScannerCartView layout cycling and drawer stability #Apps-2669

### DIFF
--- a/Cart/Sources/Views/ShoppingCartItemsView.swift
+++ b/Cart/Sources/Views/ShoppingCartItemsView.swift
@@ -1,6 +1,6 @@
 //
 //  ShoppingCartItemsView.swift
-//  
+//
 //
 //  Created by Uwe Tilemann on 22.03.23.
 //
@@ -41,6 +41,17 @@ extension ShoppingCartViewModel {
     }
 }
 
+// Preference key to propagate the first two row heights out of the List without
+// triggering the "Geometry action is cycling" warning that onGeometryChange causes
+// when used inside List in iOS 18.
+private struct RowHeightPreferenceKey: PreferenceKey {
+    typealias Value = [Int: CGFloat]
+    static let defaultValue: [Int: CGFloat] = [:]
+    static func reduce(value: inout [Int: CGFloat], nextValue: () -> [Int: CGFloat]) {
+        value.merge(nextValue(), uniquingKeysWith: { max($0, $1) })
+    }
+}
+
 public struct ShoppingCartItemsView<Footer: View>: View {
     @Bindable var cartModel: ShoppingCartViewModel
     var footer: Footer
@@ -61,9 +72,17 @@ public struct ShoppingCartItemsView<Footer: View>: View {
                     ForEach(Array(cartModel.items.enumerated()), id: \.element.id) { index, item in
                         cartModel.view(for: item)
                             .environment(cartModel)
-                            .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                            .background {
+                                // Only measure the first two rows — using GeometryReader +
+                                // PreferenceKey avoids the cycling warning that onGeometryChange
+                                // produces inside List (known iOS 18 issue).
                                 if index < 2 {
-                                    onPreviewRowHeight?(index, height)
+                                    GeometryReader { geo in
+                                        Color.clear.preference(
+                                            key: RowHeightPreferenceKey.self,
+                                            value: [index: geo.size.height]
+                                        )
+                                    }
                                 }
                             }
                             .swipeActions(allowsFullSwipe: false) {
@@ -83,6 +102,11 @@ public struct ShoppingCartItemsView<Footer: View>: View {
             .scrollBounceBehavior(.basedOnSize)
             .scrollContentBackground(.hidden)
             .background(.clear)
+            .onPreferenceChange(RowHeightPreferenceKey.self) { heights in
+                for (index, height) in heights where height > 0 {
+                    onPreviewRowHeight?(index, height)
+                }
+            }
         }
     }
 

--- a/ScanAndGo/Shopping/Views/PullOverView.swift
+++ b/ScanAndGo/Shopping/Views/PullOverView.swift
@@ -73,10 +73,24 @@ struct PullView: ViewModifier {
     func maxHeight(_ geom: GeometryProxy) -> CGFloat {
         geom.size.height
     }
-    func setupMinHeight(geom: GeometryProxy) {
+    // animated: true for user-visible height changes (minHeight, paddingTop).
+    // false for initial layout and device rotation — those should be instant.
+    func setupMinHeight(geom: GeometryProxy, animated: Bool = false) {
         guard geom.size.height > 0, !isDragging else { return }
-        minYPosition = maxHeight(geom) - (minHeight > 0 ? minHeight : paddingTop)
-        position = expanded ? paddingTop : minYPosition
+        // When minHeight hasn't been measured yet, offer half the screen so content
+        // can render at its natural size and report a correct measurement.
+        // Using only paddingTop (20pt) would compress content and cause the measured
+        // height to oscillate upward frame by frame until convergence.
+        let effective = minHeight > paddingTop ? minHeight : geom.size.height / 2
+        let newMinYPosition = maxHeight(geom) - effective
+        let newPosition = expanded ? paddingTop : newMinYPosition
+        guard minYPosition != newMinYPosition || position != newPosition else { return }
+        minYPosition = newMinYPosition
+        if animated {
+            withAnimation(.default) { position = newPosition }
+        } else {
+            position = newPosition
+        }
     }
     func body(content: Content) -> some View {
         GeometryReader { geom in
@@ -100,17 +114,16 @@ struct PullView: ViewModifier {
                 setupMinHeight(geom: geom)
             }
             .onChange(of: minHeight) {
-                setupMinHeight(geom: geom)
+                setupMinHeight(geom: geom, animated: true)
             }
             .onChange(of: paddingTop) {
-                setupMinHeight(geom: geom)
+                setupMinHeight(geom: geom, animated: true)
             }
             .onChange(of: expanded) {
                 setupMinHeight(geom: geom)
             }
             .frame(maxHeight: CGFloat(max(maxHeight(geom) - (position + dragOffset), 0)))
             .offset(y: max(0, position + dragOffset))
-            .animation(.default, value: minYPosition)
             .opacity(position == 0 ? 0 : 1)
             .simultaneousGesture(DragGesture(minimumDistance: 10, coordinateSpace: .local)
                 .onChanged { drag in

--- a/ScanAndGo/Shopping/Views/ScannerCartView.swift
+++ b/ScanAndGo/Shopping/Views/ScannerCartView.swift
@@ -27,34 +27,11 @@ struct ScannerCartView: View {
         self.offset = offset
     }
 
-    var body: some View {
-        VStack(spacing: 0) {
-            CartCheckoutBarView(model: model)
-                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
-                    measuredBarHeight = height
-                    updateMinHeight()
-                }
-            ShoppingCartView(cartModel: model.cartModel, compactMode: compactMode) { index, height in
-                measuredRowHeights[index] = height
-                updateMinHeight()
-            }
-            // Without this Spacer(), we have a transparent background
-            Spacer(minLength: 1)
-        }
-        .animation(.default, value: minHeight)
-        .task {
-            for await _ in NotificationCenter.default.notifications(named: .snabbleCartUpdated) {
-                updateMinHeight()
-            }
-        }
-        .onChange(of: model.cartModel.items) {
-            updateMinHeight()
-        }
-    }
-
-    func updateMinHeight() {
-        guard measuredBarHeight > 0 else { return }
-        let count = model.barcodeManager.shoppingCart.numberOfItems
+    // Accessed during body evaluation so SwiftUI tracks model.cartModel.items via
+    // @Observable and re-renders this view when items are added or removed.
+    private var computedHeight: CGFloat {
+        guard measuredBarHeight > 0 else { return 0 }
+        let count = model.cartModel.items.count
         // listRowInsets adds 4pt top + 4pt bottom per row
         let rowInsets: CGFloat = 8
         let rowsHeight: CGFloat
@@ -66,6 +43,45 @@ struct ScannerCartView: View {
         default:
             rowsHeight = measuredRowHeights[0] + measuredRowHeights[1] + rowInsets * 2
         }
-        minHeight = measuredBarHeight + offset + rowsHeight
+        return measuredBarHeight + offset + rowsHeight
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            CartCheckoutBarView(model: model)
+                // fixedSize forces the bar to use its natural (ideal) height regardless of
+                // how much space the VStack offers. Without this, PrimaryButtonView (which
+                // has no explicit height) can cause CartCheckoutBarView to fill the entire
+                // screen when position=0 on the initial render, producing a wildly large
+                // measuredBarHeight that pushes the drawer to the top of the screen.
+                .fixedSize(horizontal: false, vertical: true)
+                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { height in
+                    guard height > 0, measuredBarHeight != height else { return }
+                    measuredBarHeight = height
+                }
+            ShoppingCartView(cartModel: model.cartModel, compactMode: compactMode) { index, height in
+                guard measuredRowHeights[index] != height else { return }
+                measuredRowHeights[index] = height
+            }
+            // layoutPriority(1) ensures ShoppingCartView claims all remaining space before
+            // the Spacer below. Without this, fixedSize on the bar causes SwiftUI to split
+            // the remaining space equally between ShoppingCartView and the Spacer,
+            // which pushes list items toward the middle of the drawer.
+            .layoutPriority(1)
+            // Spacer fills remaining space so PullView's .regularMaterial background shows
+            // below the cart items.
+            Spacer(minLength: 1)
+        }
+        // Single write point. Skip the write when row heights for the current item
+        // count haven't been measured yet: onPreferenceChange fires in the same layout
+        // pass and will trigger another onChange with the fully-measured value, avoiding
+        // two writes per frame (which causes the "tried to update multiple times" warning).
+        .onChange(of: computedHeight) { _, newValue in
+            let count = model.cartModel.items.count
+            guard newValue > 0, minHeight != newValue else { return }
+            if count >= 1 && measuredRowHeights[0] == 0 { return }
+            if count >= 2 && measuredRowHeights[1] == 0 { return }
+            minHeight = newValue
+        }
     }
 }


### PR DESCRIPTION
Fixes regressions introduced in #481 that caused layout cycling warnings and an incorrect drawer position.

## Problems fixed

**`onChange(of: CGFloat) action tried to update multiple times per frame`**
Multiple `onGeometryChange` callbacks each wrote to `minHeight` independently.
Replaced with a single `computedHeight` computed property; `onChange(of: computedHeight)`
is now the sole writer of `minHeight`.

**`Geometry action is cycling between duplicate values` inside List**
`onGeometryChange` inside `List` has a known iOS 17 cycling bug. Replaced with
`GeometryReader` + `RowHeightPreferenceKey` + `onPreferenceChange` in
`ShoppingCartItemsView`.

**Drawer always at top of screen in collapsed state**
`PrimaryButtonView` has no explicit height, making `CartCheckoutBarView` greedy
when `position = 0` gives the drawer the full screen height on first render.
Added `.fixedSize(horizontal: false, vertical: true)` to force the natural bar
height regardless of offered space. Added `.layoutPriority(1)` on `ShoppingCartView`
to prevent equal space-sharing with the `Spacer` below.

**Drawer position not animating smoothly on height changes**
`.animation(.default, value: minYPosition)` in `PullView` caused SwiftUI to
animate `frame(maxHeight:)` changes, compressing `CartCheckoutBarView` mid-animation
and triggering a second `onGeometryChange` → second `minHeight` write in the same
frame. Removed the view animation modifier; `setupMinHeight` now accepts an
`animated:` parameter and uses `withAnimation` selectively for `onChange(of: minHeight)`
and `onChange(of: paddingTop)`.