### PR TITLE
Add `hasValidPhoneNumber` to `User`

### DIFF
--- a/User/Sources/Model/User.swift
+++ b/User/Sources/Model/User.swift
@@ -209,6 +209,17 @@ extension User {
         }
         return "+\(code)\(number)"
     }
+
+    /// Returns `true` only when the user has a complete, non-empty phone number.
+    /// Unlike `phoneNumber`, this correctly rejects partial data such as a country
+    /// code without a subscriber number (e.g. `phone.code = 49, phone.number = ""`),
+    /// which would cause `phoneNumber` to return `"+49"` — non-nil and non-empty.
+    public var hasValidPhoneNumber: Bool {
+        if let phone {
+            return phone.number?.isEmpty == false
+        }
+        return metadata?.phoneNumber?.isEmpty == false
+    }
 }
 
 extension User {


### PR DESCRIPTION
`phoneNumber` can return a non-nil, non-empty string like "+49" when `phone.code` is set but `phone.number` is empty — making it unsuitable for validation. `hasValidPhoneNumber` checks both fields directly and is safe to use where an actual subscriber number is required.