### PR TITLE
ci: migrate to Xcode Workspace and fix Swift 6.2 strict concurrency in tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   Test:
-    runs-on: macos-15
+    runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
 
     steps:
       - uses: actions/checkout@v4
       - name: Test Network
-        run: xcodebuild -scheme Snabble-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' test
+        run: xcodebuild -scheme Snabble-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,9 +16,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Test SnabbleNetwork
-        run: xcodebuild -workspace Snabble.xcworkspace -scheme SnabbleNetwork -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
-      - name: Test SnabbleCore
-        run: xcodebuild -workspace Snabble.xcworkspace -scheme SnabbleCore -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
-      - name: Test SnabblePhoneAuth
-        run: xcodebuild -workspace Snabble.xcworkspace -scheme SnabblePhoneAuth -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
+      - name: Test
+        run: xcodebuild -workspace .swiftpm/xcode/package.xcworkspace -scheme Snabble-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,5 +16,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Test
-        run: xcodebuild -workspace Snabble.xcworkspace -scheme Snabble -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
+      - name: Test SnabbleNetwork
+        run: xcodebuild -workspace Snabble.xcworkspace -scheme SnabbleNetwork -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
+      - name: Test SnabbleCore
+        run: xcodebuild -workspace Snabble.xcworkspace -scheme SnabbleCore -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
+      - name: Test SnabblePhoneAuth
+        run: xcodebuild -workspace Snabble.xcworkspace -scheme SnabblePhoneAuth -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ jobs:
   Test:
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,5 +16,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Test Network
-        run: xcodebuild -scheme Snabble-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
+      - name: Test
+        run: xcodebuild -workspace Snabble.xcworkspace -scheme Snabble -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test
-        run: xcodebuild -workspace .swiftpm/xcode/package.xcworkspace -scheme Snabble-Package -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' test
+        run: xcodebuild -workspace .swiftpm/xcode/package.xcworkspace -scheme Snabble-Package -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' test

--- a/Core/Tests/CartTests.swift
+++ b/Core/Tests/CartTests.swift
@@ -94,7 +94,7 @@ struct Mock {
         return cart
     }
 
-    static let formatter = PriceFormatter(2, "de_DE",  "EUR", "€")
+    nonisolated(unsafe) static let formatter = PriceFormatter(2, "de_DE",  "EUR", "€")
 }
 
 class ShoppingCartTests: XCTestCase {

--- a/Core/Tests/MockProducts.swift
+++ b/Core/Tests/MockProducts.swift
@@ -111,7 +111,7 @@ class MockProductDB: ProductStoring & ProductProviding {
                             type: .singleItem,
                             codes: [])
 
-    private static var productMap = [String: Product]()
+    private nonisolated(unsafe) static var productMap = [String: Product]()
     private static let allProducts = [p1, p2, p3, p4, p5]
 
     required init(_ config: Config, _ project: Project) {

--- a/Core/Tests/SnabbleTests.swift
+++ b/Core/Tests/SnabbleTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 @testable import SnabbleCore
 
-class SnabbleTests: XCTestCase {
+class SnabbleTests: XCTestCase, @unchecked Sendable {
     
     override func setUp() {
         super.setUp()

--- a/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
+++ b/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		761C0E092F7145730000BFF1 /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 761C0E082F7145730000BFF1 /* Snabble */; };
 		766BCCCA2F62C23A00D8FFAF /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 766BCCC92F62C23A00D8FFAF /* Snabble */; };
+		768DFC1D3017286900149045 /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 768DFC1C3017286900149045 /* Snabble */; };
 		76CFCD1E2F76B7F500166D12 /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 76CFCD1D2F76B7F500166D12 /* Snabble */; };
 		76DF385B2F5075A80050F4EC /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 76DF385A2F5075A80050F4EC /* Snabble */; };
 /* End PBXBuildFile section */
@@ -48,6 +49,7 @@
 				761C0E092F7145730000BFF1 /* Snabble in Frameworks */,
 				766BCCCA2F62C23A00D8FFAF /* Snabble in Frameworks */,
 				76CFCD1E2F76B7F500166D12 /* Snabble in Frameworks */,
+				768DFC1D3017286900149045 /* Snabble in Frameworks */,
 				76DF385B2F5075A80050F4EC /* Snabble in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -108,6 +110,7 @@
 				766BCCC92F62C23A00D8FFAF /* Snabble */,
 				761C0E082F7145730000BFF1 /* Snabble */,
 				76CFCD1D2F76B7F500166D12 /* Snabble */,
+				768DFC1C3017286900149045 /* Snabble */,
 			);
 			productName = SwiftySnabble;
 			productReference = 76DF38052F50740F0050F4EC /* SnabbleSampleApp.app */;
@@ -139,7 +142,7 @@
 			mainGroup = 76DF37FC2F50740F0050F4EC;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				76CFCD1C2F76B7F500166D12 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */,
+				768DFC1B3017286900149045 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 76DF38062F50740F0050F4EC /* Products */;
@@ -471,7 +474,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		76CFCD1C2F76B7F500166D12 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */ = {
+		768DFC1B3017286900149045 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "../../snabble-ios-sdk";
 		};
@@ -483,6 +486,10 @@
 			productName = Snabble;
 		};
 		766BCCC92F62C23A00D8FFAF /* Snabble */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Snabble;
+		};
+		768DFC1C3017286900149045 /* Snabble */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Snabble;
 		};

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: test test-network test-core test-phoneauth
+
+WORKSPACE = .swiftpm/xcode/package.xcworkspace
+SCHEME    = Snabble-Package
+DESTINATION = platform=iOS Simulator,name=iPhone 17 Pro,OS=latest
+
+test:
+	xcodebuild -workspace $(WORKSPACE) -scheme $(SCHEME) \
+		-destination '$(DESTINATION)' test
+
+test-network:
+	xcodebuild -workspace $(WORKSPACE) -scheme Snabble-Package \
+		-destination '$(DESTINATION)' test \
+		-only-testing SnabbleNetworkTests
+
+test-core:
+	xcodebuild -workspace $(WORKSPACE) -scheme Snabble-Package \
+		-destination '$(DESTINATION)' test \
+		-only-testing SnabbleCoreTests
+
+test-phoneauth:
+	xcodebuild -workspace $(WORKSPACE) -scheme Snabble-Package \
+		-destination '$(DESTINATION)' test \
+		-only-testing SnabblePhoneAuthTests

--- a/Network/Sources/Models/Configuration.swift
+++ b/Network/Sources/Models/Configuration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Configuration: Equatable, Hashable {
+public struct Configuration: Equatable, Hashable, Sendable {
     public let appId: String
     public let appSecret: String
     public let domain: Domain

--- a/Network/Sources/Models/Domain.swift
+++ b/Network/Sources/Models/Domain.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Domain: String {
+public enum Domain: String, Sendable {
     case testing
     case staging
     case production

--- a/Network/Tests/AuthenticatorTests.swift
+++ b/Network/Tests/AuthenticatorTests.swift
@@ -7,7 +7,6 @@
 
 import XCTest
 @testable import SnabbleNetwork
-import Combine
 
 // Thread-safe counter for verifying request counts across concurrent network calls.
 private final class RequestCounter: @unchecked Sendable {
@@ -18,12 +17,13 @@ private final class RequestCounter: @unchecked Sendable {
     func increment() { lock.withLock { _count += 1 } }
 }
 
-final class AuthenticatorTests: XCTestCase {
+extension Authenticator: @unchecked Sendable {}
+
+@MainActor
+final class AuthenticatorTests: XCTestCase, @unchecked Sendable {
 
     var authenticator: Authenticator!
-    var cancellables = Set<AnyCancellable>()
     var configuration = Configuration(appId: "123", appSecret: "123-456-789", domain: .testing)
-    var urlSession: URLSession = .mockSession
 
     override func setUpWithError() throws {
         authenticator = .init(urlSession: .mockSession)
@@ -63,31 +63,14 @@ final class AuthenticatorTests: XCTestCase {
                 )!
                 return (response, Data())
             }
-
         }
-        let expectation = expectation(description: "validateToken")
-        authenticator.validToken(withConfiguration: configuration)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    XCTAssertThrowsError(error)
-                }
-                expectation.fulfill()
-            } receiveValue: { token in
-                XCTAssertNotNil(token)
-            }
-            .store(in: &cancellables)
-#if swift(>=5.8)
-        await fulfillment(of: [expectation], timeout: 5)
-#else
-        wait(for: [expectation], timeout: 5)
-#endif
+
+        let token = try await authenticator.validToken(withConfiguration: configuration)
+        XCTAssertNotNil(token)
     }
 
-    /// Verifies that concurrent calls to validToken share a single upstream chain and
-    /// therefore fire POST /users exactly once, not once per subscriber.
+    /// Verifies that concurrent calls to validToken share a single in-flight task and
+    /// therefore fire POST /users exactly once, not once per caller.
     func testConcurrentValidTokenCallsFireOnlyOnePostRequest() async throws {
         let postCounter = RequestCounter()
 
@@ -112,21 +95,14 @@ final class AuthenticatorTests: XCTestCase {
             }
         }
 
-        let e1 = expectation(description: "subscriber1")
-        let e2 = expectation(description: "subscriber2")
-        let e3 = expectation(description: "subscriber3")
+        // All three tasks start before any response arrives; they share the same refreshTask.
+        async let t1 = authenticator.validToken(withConfiguration: configuration)
+        async let t2 = authenticator.validToken(withConfiguration: configuration)
+        async let t3 = authenticator.validToken(withConfiguration: configuration)
+        _ = try await (t1, t2, t3)
 
-        // All three subscribe synchronously before URLSession dispatches the response,
-        // so they all share the same in-flight request via Publishers.Share.
-        for exp in [e1, e2, e3] {
-            authenticator.validToken(withConfiguration: configuration)
-                .sink { _ in exp.fulfill() } receiveValue: { _ in }
-                .store(in: &cancellables)
-        }
-
-        await fulfillment(of: [e1, e2, e3], timeout: 5)
         XCTAssertEqual(postCounter.count, 1,
-            "POST /users must be fired exactly once regardless of concurrent subscriber count")
+            "POST /users must be fired exactly once regardless of concurrent caller count")
     }
 
     /// Verifies that the token received from the first validToken call is cached and
@@ -157,19 +133,11 @@ final class AuthenticatorTests: XCTestCase {
             }
         }
 
-        // First call: must fetch AppUser (POST) and Token (GET)
-        let firstExpectation = expectation(description: "first call")
-        authenticator.validToken(withConfiguration: configuration)
-            .sink { _ in firstExpectation.fulfill() } receiveValue: { _ in }
-            .store(in: &cancellables)
-        await fulfillment(of: [firstExpectation], timeout: 5)
+        // First call: fetches AppUser (POST) and Token (GET)
+        _ = try await authenticator.validToken(withConfiguration: configuration)
 
-        // Second call: must return the cached token without any network requests
-        let secondExpectation = expectation(description: "second call — cached")
-        authenticator.validToken(withConfiguration: configuration)
-            .sink { _ in secondExpectation.fulfill() } receiveValue: { _ in }
-            .store(in: &cancellables)
-        await fulfillment(of: [secondExpectation], timeout: 5)
+        // Second call: must return the cached token without new network requests
+        _ = try await authenticator.validToken(withConfiguration: configuration)
 
         XCTAssertEqual(postCounter.count, 1, "POST /users must not repeat after token is cached")
         XCTAssertEqual(tokenCounter.count, 1, "GET /tokens must not repeat after token is cached")

--- a/Network/Tests/Helper/MockURLProtocol.swift
+++ b/Network/Tests/Helper/MockURLProtocol.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public class MockURLProtocol: URLProtocol {
-    public static var error: Error?
-    public static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    public nonisolated(unsafe) static var error: Error?
+    public nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override public class func canInit(with request: URLRequest) -> Bool {
         return true

--- a/Network/Tests/NetworkManagerTests.swift
+++ b/Network/Tests/NetworkManagerTests.swift
@@ -1,25 +1,23 @@
 //
 //  NetworkManagerTests.swift
-//  
+//
 //
 //  Created by Andreas Osberghaus on 2023-05-15.
 //
 
 import XCTest
 import Foundation
-import Combine
 
 @testable import SnabbleNetwork
 
+@MainActor
 final class NetworkManagerTests: XCTestCase {
 
-    var cancellables: Set<AnyCancellable>!
     var networkManager: NetworkManager!
     var configuration: SnabbleNetwork.Configuration = .init(appId: "123", appSecret: "2", domain: .production)
     var appUser: AppUser?
 
     override func setUpWithError() throws {
-        cancellables = Set<AnyCancellable>()
         networkManager = NetworkManager(configuration: configuration, urlSession: .mockSession)
         networkManager.delegate = self
 
@@ -63,11 +61,10 @@ final class NetworkManagerTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        cancellables = nil
         networkManager = nil
     }
 
-    func testRequestWithError() throws {
+    func testRequestWithError() async throws {
         MockURLProtocol.error = nil
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
@@ -81,46 +78,23 @@ final class NetworkManagerTests: XCTestCase {
 
         let endpoint = Endpoints.AppUser.post(appId: configuration.appId, appSecret: configuration.appSecret)
 
-        let expectation = expectation(description: "register")
-        networkManager.publisher(for: endpoint)
-            .sink { completion in
-                switch completion {
-                case .failure:
-                    expectation.fulfill()
-                case .finished:
-                    break
-                }
-            } receiveValue: { validation in
-                XCTAssertNil(validation)
-            }
-            .store(in: &cancellables)
-
-        wait(for: [expectation], timeout: 3.0)
+        do {
+            _ = try await networkManager.publisher(for: endpoint)
+            XCTFail("Expected error but request succeeded")
+        } catch {
+            XCTAssertNotNil(error)
+        }
     }
 
-    func testEndpoint() throws {
+    func testEndpoint() async throws {
         let endpoint = Endpoints.Phone.auth(phoneNumber: "+4915119695415")
 
-        let expectation = expectation(description: "auth")
-        networkManager.publisher(for: endpoint)
-            .sink { completion in
-                switch completion {
-                case .failure(let error):
-                    XCTAssertThrowsError(error)
-                case .finished:
-                    break
-                }
-                expectation.fulfill()
-            } receiveValue: { value in
-                print("foobar")
-                print(value)
-            }
-            .store(in: &cancellables)
-
-        wait(for: [expectation], timeout: 10.0)
+        do {
+            _ = try await networkManager.publisher(for: endpoint)
+        } catch {
+            XCTAssertNotNil(error)
+        }
     }
-
-    
 }
 
 extension NetworkManagerTests: NetworkManagerDelegate {

--- a/Network/Tests/URLSessionEndpointTests.swift
+++ b/Network/Tests/URLSessionEndpointTests.swift
@@ -6,20 +6,16 @@
 //
 
 import XCTest
-import Combine
 @testable import SnabbleNetwork
 
 final class URLSessionEndpointTests: XCTestCase {
 
     let resourceData = try! loadResource(inBundle: .module, filename: "UsersResponse", withExtension: "json")
     let endpointUsers: Endpoint<UsersResponse> = Endpoints.AppUser.post(appId: "123-456-789", appSecret: "1")
-    var cancellables = Set<AnyCancellable>()
 
-    // MARK: - Decodable
-
-    func testCombine() async throws {
+    func testData() async throws {
         MockURLProtocol.error = nil
-        MockURLProtocol.requestHandler = { [unowned self] request in
+        MockURLProtocol.requestHandler = { [self] request in
             let response = HTTPURLResponse(
                 url: URL(string: "https://api.snabble.io/apps/123-456-789/users")!,
                 statusCode: 200,
@@ -29,57 +25,25 @@ final class URLSessionEndpointTests: XCTestCase {
             return (response, resourceData)
         }
 
-        let expectation = expectation(description: "users")
         let session = URLSession.mockSession
-        session.dataTaskPublisher(for: endpointUsers)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                    XCTAssertTrue(true)
-                case .failure(let error):
-                    XCTAssertNil(error)
-                }
-                expectation.fulfill()
-            } receiveValue: { usersReponse in
-                XCTAssertNotNil(usersReponse)
-            }
-            .store(in: &cancellables)
-
-#if swift(>=5.8)
-        await fulfillment(of: [expectation], timeout: 5)
-#else
-        wait(for: [expectation], timeout: 5.0)
-#endif
+        let usersResponse = try await session.data(for: endpointUsers)
+        XCTAssertNotNil(usersResponse)
     }
 
-    func testCombineError() async throws {
+    func testDataError() async throws {
         MockURLProtocol.error = URLError(.unknown)
         MockURLProtocol.requestHandler = nil
 
-        let expectation = expectation(description: "users")
         let session = URLSession.mockSession
-        session.dataTaskPublisher(for: endpointUsers)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                    XCTAssertTrue(true)
-                case .failure(let error):
-                    XCTAssertNotNil(error)
-                }
-                expectation.fulfill()
-            } receiveValue: { credentials in
-                XCTAssertNil(credentials)
-            }
-            .store(in: &cancellables)
-
-#if swift(>=5.8)
-        await fulfillment(of: [expectation], timeout: 5)
-#else
-        wait(for: [expectation], timeout: 5.0)
-#endif
+        do {
+            _ = try await session.data(for: endpointUsers)
+            XCTFail("Expected URLError but request succeeded")
+        } catch {
+            XCTAssertNotNil(error)
+        }
     }
 
-    func testDecodableCombineInvalidResponse() async throws {
+    func testDataInvalidResponse() async throws {
         MockURLProtocol.error = nil
         MockURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(
@@ -91,31 +55,14 @@ final class URLSessionEndpointTests: XCTestCase {
             return (response, Data())
         }
 
-        let expectation = expectation(description: "register")
         let session = URLSession.mockSession
-        session.dataTaskPublisher(for: endpointUsers)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                    XCTAssertTrue(true)
-                case .failure(let error):
-                    XCTAssertNotNil(error)
-                    if case HTTPError.invalid(let response, _) = error {
-                        XCTAssertEqual(response.httpStatusCode, .notFound)
-                    } else {
-                        XCTFail("should ne httpError invalidResponse")
-                    }
-                }
-                expectation.fulfill()
-            } receiveValue: { credentials in
-                XCTAssertNil(credentials)
-            }
-            .store(in: &cancellables)
-
-#if swift(>=5.8)
-        await fulfillment(of: [expectation], timeout: 5)
-#else
-        wait(for: [expectation], timeout: 5.0)
-#endif
+        do {
+            _ = try await session.data(for: endpointUsers)
+            XCTFail("Expected HTTPError but request succeeded")
+        } catch let HTTPError.invalid(response, _) {
+            XCTAssertEqual(response.httpStatusCode, .notFound)
+        } catch {
+            XCTFail("Expected HTTPError.invalid but got \(error)")
+        }
     }
 }

--- a/Snabble.xcworkspace/contents.xcworkspacedata
+++ b/Snabble.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace version = "1.0">
+    <FileRef location="group:Package.swift"/>
+   <FileRef location="group:Example/SnabbleSampleApp.xcodeproj"/>
+</Workspace>

--- a/Snabble.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Snabble.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<true/>
+</dict>
+</plist>

--- a/Snabble.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Snabble.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e74a972cd6498e1d99670ee21539ef45f02d3bcbeee16f26f8db6c447fca3057",
+  "originHash" : "b91ad84f228b3db8bc21ce372b618f8fe12362551c4802236db9e991a8482bec",
   "pins" : [
     {
       "identity" : "camerazoomwheel",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -62,15 +62,6 @@
       "state" : {
         "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
         "version" : "3.15.1"
-      }
-    },
-    {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Converted project from standalone Swift Package to an Xcode Workspace (`Snabble.xcworkspace`)
- Upgraded CI to `macos-26` / `Xcode 26.6` to support `swift-tools-version: 6.3`
- Used `.swiftpm/xcode/package.xcworkspace` in CI so the `Snabble-Package` scheme (with test actions) is available
- Migrated all test targets to Swift 6.2 strict concurrency

## Details

**CI (`swift.yml`)**
- Runner: `macos-15` → `macos-26`
- Xcode: `Xcode_16.4` → `Xcode_26.6`
- Workspace: `Snabble.xcworkspace` → `.swiftpm/xcode/package.xcworkspace`
- Destination: `iPhone 16, OS=18.5` → `iPhone 17 Pro, OS=latest`

**Test migration (Swift 6.2 strict concurrency)**
- `NetworkManagerTests`, `AuthenticatorTests`, `URLSessionEndpointTests`: Rewritten from Combine (`.sink`) to `async/await`; classes marked `@MainActor`
- `Configuration`, `Domain`: Added `Sendable` conformance
- `MockURLProtocol`, `MockProducts`, `CartTests`, `SnabbleTests`: Static mutable state annotated with `nonisolated(unsafe)` or `@unchecked Sendable`

## Test plan

- [x] CI passes on GitHub Actions (`macos-26` runner)
- [x] `xcodebuild` with `.swiftpm/xcode/package.xcworkspace -scheme Snabble-Package` runs all test targets successfully