### PR TITLE
fix: resolve Xcode Cloud build failures in SnabbleSampleApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ build/
 !default.perspectivev3
 xcuserdata/
 *.xccheckout
-profile
+*.profile
 *.moved-aside
 DerivedData
 *.hmap

--- a/Core/Sources/API/SDKVersion.swift
+++ b/Core/Sources/API/SDKVersion.swift
@@ -5,5 +5,5 @@
 //
 
 public var SDKVersion: String {
-    "1.1.2"
+    "1.1.3"
 }

--- a/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
+++ b/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
@@ -480,9 +480,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		7621261A301797FD00BAE786 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */ = {
+		7621261A301797FD00BAE786 /* XCLocalSwiftPackageReference ".." */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../snabble-ios-sdk";
+			relativePath = "..";
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
+++ b/Example/SnabbleSampleApp.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		761C0E092F7145730000BFF1 /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 761C0E082F7145730000BFF1 /* Snabble */; };
+		761E65E93017961E00B0662C /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 761E65E83017961E00B0662C /* Snabble */; };
+		7621261C301797FD00BAE786 /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 7621261B301797FD00BAE786 /* Snabble */; };
 		766BCCCA2F62C23A00D8FFAF /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 766BCCC92F62C23A00D8FFAF /* Snabble */; };
 		768DFC1D3017286900149045 /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 768DFC1C3017286900149045 /* Snabble */; };
 		76CFCD1E2F76B7F500166D12 /* Snabble in Frameworks */ = {isa = PBXBuildFile; productRef = 76CFCD1D2F76B7F500166D12 /* Snabble */; };
@@ -46,11 +48,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				761E65E93017961E00B0662C /* Snabble in Frameworks */,
 				761C0E092F7145730000BFF1 /* Snabble in Frameworks */,
 				766BCCCA2F62C23A00D8FFAF /* Snabble in Frameworks */,
 				76CFCD1E2F76B7F500166D12 /* Snabble in Frameworks */,
 				768DFC1D3017286900149045 /* Snabble in Frameworks */,
 				76DF385B2F5075A80050F4EC /* Snabble in Frameworks */,
+				7621261C301797FD00BAE786 /* Snabble in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -111,6 +115,8 @@
 				761C0E082F7145730000BFF1 /* Snabble */,
 				76CFCD1D2F76B7F500166D12 /* Snabble */,
 				768DFC1C3017286900149045 /* Snabble */,
+				761E65E83017961E00B0662C /* Snabble */,
+				7621261B301797FD00BAE786 /* Snabble */,
 			);
 			productName = SwiftySnabble;
 			productReference = 76DF38052F50740F0050F4EC /* SnabbleSampleApp.app */;
@@ -142,7 +148,7 @@
 			mainGroup = 76DF37FC2F50740F0050F4EC;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				768DFC1B3017286900149045 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */,
+				7621261A301797FD00BAE786 /* XCLocalSwiftPackageReference ".." */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 76DF38062F50740F0050F4EC /* Products */;
@@ -474,7 +480,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		768DFC1B3017286900149045 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */ = {
+		7621261A301797FD00BAE786 /* XCLocalSwiftPackageReference "../../snabble-ios-sdk" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "../../snabble-ios-sdk";
 		};
@@ -482,6 +488,14 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		761C0E082F7145730000BFF1 /* Snabble */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Snabble;
+		};
+		761E65E83017961E00B0662C /* Snabble */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Snabble;
+		};
+		7621261B301797FD00BAE786 /* Snabble */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Snabble;
 		};

--- a/Example/SwiftySnabble/Features/Profile/EnvironmentSelectorView.swift
+++ b/Example/SwiftySnabble/Features/Profile/EnvironmentSelectorView.swift
@@ -1,0 +1,48 @@
+//
+//  EnvironmentSelectorView.swift
+//  SwiftySnabble
+//
+//  Created by Uwe Tilemann on 18.05.26.
+//  Copyright (c) 2026 snabble GmbH. All rights reserved.
+//
+import SwiftUI
+
+import SnabbleCore
+import SnabbleTheme
+
+struct EnvironmentSelectorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedEnvironment = DeveloperMode.environmentMode
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach([Snabble.Environment.production, .staging, .testing], id: \.self) { env in
+                    Button {
+                        selectedEnvironment = env
+                        // Note: Environment switching requires app restart
+                        dismiss()
+                    } label: {
+                        HStack {
+                            Text(env.rawValue)
+                            Spacer()
+                            if env == selectedEnvironment {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Environment")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/Example/SwiftySnabble/Features/Profile/HTMLContentView.swift
+++ b/Example/SwiftySnabble/Features/Profile/HTMLContentView.swift
@@ -1,0 +1,46 @@
+//
+//  HTMLContentView.swift
+//  SwiftySnabble
+//
+//  Created by Uwe Tilemann on 18.05.26.
+//  Copyright (c) 2026 snabble GmbH. All rights reserved.
+//
+import SwiftUI
+
+import SnabbleComponents
+
+struct HTMLContentView: View {
+    let title: String
+    let htmlFileName: String
+    @State private var htmlContent: String?
+    
+    var body: some View {
+        Group {
+            if let htmlContent {
+                SnabbleComponents.HTMLView(string: htmlContent)
+            } else {
+                VStack(spacing: 16) {
+                    ProgressView()
+                    Text("Loading \(title)...")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            await loadHTML()
+        }
+    }
+    
+    private func loadHTML() async {
+        guard let url = Bundle.main.url(forResource: htmlFileName, withExtension: "html"),
+              let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return
+        }
+        htmlContent = content
+    }
+}
+

--- a/Example/SwiftySnabble/Features/Profile/PaymentMethodsViewWrapper.swift
+++ b/Example/SwiftySnabble/Features/Profile/PaymentMethodsViewWrapper.swift
@@ -1,0 +1,40 @@
+//
+//  PaymentMethodsViewWrapper.swift
+//  SwiftySnabble
+//
+//  Created by Uwe Tilemann on 18.05.26.
+//  Copyright (c) 2026 snabble GmbH. All rights reserved.
+//
+import SwiftUI
+
+import SnabbleCore
+import SnabbleAssetProviding
+import SnabbleTheme
+import SnabbleComponents
+import SnabblePayment
+
+extension String {
+    /// Localize the String on the `main` Bundle and `nil` table.
+    var localized: String {
+        return NSLocalizedString(self, tableName: nil, bundle: Bundle.main, value: "", comment: "")
+    }
+}
+
+struct PaymentMethodsViewWrapper: View {
+    var project: SnabbleCore.Project?
+
+    var body: some View {
+        Group {
+            if let projectId = project?.id {
+                PaymentMethodListView(projectId: projectId, analyticsDelegate: nil)
+            } else {
+                SnabbleEmptyView(
+                    title: "Payments.emptyMessage".localized,
+                    image: Image("CardPayment"),
+                    imageWidth: 200
+                )
+            }
+        }
+    }
+}
+

--- a/Example/SwiftySnabble/Features/Profile/ProfileView.swift
+++ b/Example/SwiftySnabble/Features/Profile/ProfileView.swift
@@ -1,0 +1,171 @@
+//
+//  ProfileView.swift
+//  Snabble Sample App
+//
+//  Created by Uwe Tilemann on 18.05.26.
+//  Copyright (c) 2026 snabble GmbH. All rights reserved.
+//
+
+import SwiftUI
+
+import SnabbleCore
+import SnabbleAssetProviding
+import SnabbleTheme
+import SnabbleComponents
+
+struct ProfileView: View {
+    @Environment(AppRouter.self) private var router
+    @Environment(AppState.self) private var appState
+    
+    @State private var showEnvironmentSelector = false
+
+    var body: some View {
+        List {
+            Section {
+                ProfileHeaderView()
+            }
+            .listRowInsets(EdgeInsets())
+            .listRowBackground(Color.clear)
+
+            Section("Shopping") {
+                NavigationLink {
+                    ReceiptsView()
+                } label: {
+                    ProfileRow(
+                        icon: "receipt.fill",
+                        title: "Receipts",
+                        color: .orange
+                    )
+                }
+
+                NavigationLink {
+                    PaymentMethodsViewWrapper(project: appState.project)
+                } label: {
+                    ProfileRow(
+                        icon: "creditcard.fill",
+                        title: "Payment Methods",
+                        color: .blue
+                    )
+                }
+
+                NavigationLink {
+                    ContentUnavailableView {
+                        Label(Asset.localizedString(forKey: "Snabble.PaymentStatus.Payment.title") + " " + Asset.localizedString(forKey: "Snabble.Payment.payUsingCustomerCard"), systemImage: "wallet.pass.fill")
+                    } description: {
+                        Text(Asset.localizedString(forKey: "Snabble.PaymentMethods.title"))
+                    }
+                } label: {
+                    ProfileRow(
+                        icon: "wallet.pass.fill",
+                        title: "Customer Card",
+                        color: .purple
+                    )
+                }
+            }
+
+            Section("Settings") {
+                NavigationLink {
+                    HTMLContentView(title: "Privacy Policy".localized, htmlFileName: "terms")
+                } label: {
+                    ProfileRow(
+                        icon: "hand.raised.fill",
+                        title: "Privacy Policy",
+                        color: .green
+                    )
+                }
+
+                NavigationLink {
+                    HTMLContentView(title: "Imprint".localized, htmlFileName: "imprint")
+                } label: {
+                    ProfileRow(
+                        icon: "info.circle.fill",
+                        title: "Imprint",
+                        color: .gray
+                    )
+                }
+                Button {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                } label: {
+                    ProfileRow(
+                        icon: "append.page",
+                        title: "Licenses",
+                        color: .gray
+                    )
+                }
+            }
+
+            Section {
+                HStack {
+                    Spacer()
+                    VStack(spacing: 4) {
+                        Text("Snabble SDK")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text("Version \(SDKVersion)")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    .onTapGesture(count: 5) {
+                        showEnvironmentSelector.toggle()
+                    }
+                    Spacer()
+                }
+            }
+            .listRowBackground(Color.clear)
+        }
+        .navigationTitle("Profile")
+        .sheet(isPresented: $showEnvironmentSelector) {
+            EnvironmentSelectorView()
+                .presentationDetents([.medium])
+        }
+    }
+}
+
+struct ProfileHeaderView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "person.crop.circle.fill")
+                .font(.system(size: 80))
+                .foregroundColor(.blue)
+
+            VStack(spacing: 4) {
+                Text("Snabble User")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+    }
+}
+
+struct ProfileRow: View {
+    let icon: String
+    let title: LocalizedStringKey
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.body)
+                .foregroundColor(.white)
+                .frame(width: 32, height: 32)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(color.gradient)
+                )
+
+            Text(title)
+                .font(.body)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProfileView()
+            .environment(AppRouter())
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes `ProfileView` (and related files) missing in Xcode Cloud builds: the `.gitignore` pattern `profile` was case-insensitively matching the `Features/Profile/` directory on macOS, excluding all files from git. Changed to `*.profile` to only ignore Xcode profiling artifacts.
- Corrects the local Swift Package relative path in `project.pbxproj` from `../../snabble-ios-sdk` to `..` so it resolves correctly on Xcode Cloud (repo checkout at `/Volumes/workspace/repository/`).
- Bumps SDK version to 1.1.3.

## Test plan

- [ ] Xcode Cloud build for SnabbleSampleApp passes without errors
- [ ] Local build in `Snabble.xcworkspace` still works