### PR TITLE
chore: update tooling dependencies (SwiftLint 0.65.0, LicensePlist 3.28.0, macOS 26 CI)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ name: Snabble Documentation
 jobs:
   docc:
     name: docc
-    runs-on: macos-15 # https://github.com/actions/runner-images
+    runs-on: macos-26 # https://github.com/actions/runner-images
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -14,7 +14,7 @@ jobs:
   SwiftLint:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/realm/swiftlint:0.61.0
+      image: ghcr.io/realm/swiftlint:0.65.0
 
     steps:
       - uses: actions/checkout@v4

--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-realm/SwiftLint@0.64.1
-mono0926/LicensePlist@3.27.9
+realm/SwiftLint@0.65.0
+mono0926/LicensePlist@3.28.0


### PR DESCRIPTION
## Summary

- Bumps SwiftLint from 0.64.1 → 0.65.0 in `Mintfile` and GitHub Actions SwiftLint workflow
- Bumps LicensePlist from 3.27.9 → 3.28.0 in `Mintfile`
- Updates documentation workflow runner from `macos-15` → `macos-26`

## Test plan

- [x] SwiftLint workflow runs clean on the new image
- [ ] Documentation workflow completes successfully on macos-26
