### PR TITLE
fix(payment): disambiguate externalBilling by originType #Apps-998

### DIFF
--- a/Core/Sources/API/Snabble.swift
+++ b/Core/Sources/API/Snabble.swift
@@ -46,7 +46,6 @@ public struct Config {
     /// load shop list from the `activeShops` endpoint?
     public var loadActiveShops = false
 
-
     // debug mode only:
     // SQL statements that are executed just before the product database is opened
     public var initialSQL: [String]?

--- a/Core/Sources/API/Snabble.swift
+++ b/Core/Sources/API/Snabble.swift
@@ -46,9 +46,6 @@ public struct Config {
     /// load shop list from the `activeShops` endpoint?
     public var loadActiveShops = false
 
-    // Workaround: Bug Fix #APPS-995
-    // https://snabble.atlassian.net/browse/APPS-995
-    public var showExternalBilling = true
 
     // debug mode only:
     // SQL statements that are executed just before the product database is opened

--- a/Core/Sources/Metadata/Project.swift
+++ b/Core/Sources/Metadata/Project.swift
@@ -563,7 +563,7 @@ public struct Project: Decodable, Identifiable, @unchecked Sendable {
 
     public let paymentMethodDescriptors: [PaymentMethodDescriptor]
     public var paymentMethods: [RawPaymentMethod] {
-        paymentMethodDescriptors.map { $0.id }
+        paymentMethodDescriptors.compactMap { $0.resolvedMethod }
     }
     public var availablePaymentMethods: [RawPaymentMethod] {
         paymentMethods.filter { $0.isAvailable }

--- a/Core/Sources/Payment/PaymentMethods.swift
+++ b/Core/Sources/Payment/PaymentMethods.swift
@@ -16,18 +16,13 @@ public struct PaymentMethodDescriptor: Decodable {
 
     /// Resolves the specific payment method from id + acceptedOriginTypes,
     /// analogous to Android's fromIdAndOrigin().
-    /// `externalBilling` is shared between invoice login (contactPersonCredentials)
-    /// and employee/customer card (tegutEmployeeID) — the origin disambiguates.
+    /// `externalBilling` is only surfaced when `contactPersonCredentials` is present;
+    /// all other origins (e.g. tegutEmployeeID) are handled outside the payment method list.
     public var resolvedMethod: RawPaymentMethod? {
         let origins = acceptedOriginTypes ?? []
         switch id {
         case .externalBilling:
-            if origins.contains(.contactPersonCredentials) {
-                return .externalBilling
-            } else if origins.contains(.employeeID) {
-                return .customerCardPOS
-            }
-            return nil
+            return origins.contains(.contactPersonCredentials) ? .externalBilling : nil
         default:
             return id
         }
@@ -116,7 +111,7 @@ public enum RawPaymentMethod: String, Decodable, CaseIterable, Swift.Identifiabl
         case .qrCodePOS, .qrCodeOffline, .gatekeeperTerminal, .customerCardPOS, .applePay:
             return false
         case .externalBilling:
-            return Snabble.shared.config.showExternalBilling
+            return true
         }
 
     }

--- a/Core/Sources/Payment/PaymentMethods.swift
+++ b/Core/Sources/Payment/PaymentMethods.swift
@@ -13,6 +13,25 @@ public struct PaymentMethodDescriptor: Decodable {
     public struct Links: Decodable {
         public let tokenization: Link?
     }
+
+    /// Resolves the specific payment method from id + acceptedOriginTypes,
+    /// analogous to Android's fromIdAndOrigin().
+    /// `externalBilling` is shared between invoice login (contactPersonCredentials)
+    /// and employee/customer card (tegutEmployeeID) — the origin disambiguates.
+    public var resolvedMethod: RawPaymentMethod? {
+        let origins = acceptedOriginTypes ?? []
+        switch id {
+        case .externalBilling:
+            if origins.contains(.contactPersonCredentials) {
+                return .externalBilling
+            } else if origins.contains(.employeeID) {
+                return .customerCardPOS
+            }
+            return nil
+        default:
+            return id
+        }
+    }
 }
 
 public enum Provider: String, Decodable {
@@ -96,8 +115,6 @@ public enum RawPaymentMethod: String, Decodable, CaseIterable, Swift.Identifiabl
             return true
         case .qrCodePOS, .qrCodeOffline, .gatekeeperTerminal, .customerCardPOS, .applePay:
             return false
-        // Workaround: Bug Fix #APPS-995
-        // https://snabble.atlassian.net/browse/APPS-995
         case .externalBilling:
             return Snabble.shared.config.showExternalBilling
         }

--- a/Payment/Sources/PaymentMethodItem.swift
+++ b/Payment/Sources/PaymentMethodItem.swift
@@ -57,11 +57,6 @@ extension PaymentMethodItem {
                 }
                 return items
             } else {
-                // Workaround: Bug Fix #APPS-995
-                // https://snabble.atlassian.net/browse/APPS-995
-                if method == .externalBilling && Snabble.shared.config.showExternalBilling == false {
-                    return []
-                }
                 return [PaymentMethodItem(
                     title: method.displayName,
                     subtitle: Asset.localizedString(forKey: "Snabble.Shoppingcart.noPaymentData"),


### PR DESCRIPTION
## Problem

`externalBilling` is used by the backend for two distinct cases that differ only in `originType`:

| originType                  | Meaning           |
|-----------------------------|-------------------|
| `contactPersonCredentials`  | Invoice login     |
| `tegutEmployeeID`           | Customer card     |

iOS ignored the `originType` when building `Project.paymentMethods` (`paymentMethodDescriptors.map { $0.id }`), causing "Kauf auf Rechnung" to appear in shops that only support the customer card flow.

APPS-995 worked around this with a global `Config.showExternalBilling` flag.

## Fix

Mirrors Android's `fromIdAndOrigin()`:

`PaymentMethodDescriptor` gains a `resolvedMethod` property that returns `.externalBilling` only when `contactPersonCredentials` is present in `acceptedOriginTypes`, and `nil` otherwise.

`Project.paymentMethods` now uses `compactMap { $0.resolvedMethod }` instead of `map { $0.id }`.

## Changes

| File | Change |
|---|---|
| `PaymentMethods.swift` | Add `resolvedMethod` to `PaymentMethodDescriptor`; `visible` for `.externalBilling` → `true` |
| `Project.swift` | `compactMap { $0.resolvedMethod }` instead of `map { $0.id }` |
| `PaymentMethodItem.swift` | Remove APPS-995 workaround check |
| `Snabble.swift` | Remove `Config.showExternalBilling` — no longer needed |

## Notes

- All existing `paymentMethodDescriptors.first(where: { $0.id == self })` call sites are **unaffected**.
- `Config.showExternalBilling` is removed as a breaking change; justified since teo is the sole SDK consumer.

Closes APPS-998 / supersedes APPS-995